### PR TITLE
extractData2() for trend_GADSdat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* S3 method of `extractData2()` now available for `trend_GADSdat` objects
 * `recodeGADS()` and `applyChangeMeta()` allow recoding values without recoding value labels (via `existingMeta = "ignore"`)
 * `insertVariable()` has been renamed `relocateVariable()` for clarity. Variables can now be inserted at the very beginning of a `GADSdat`
 * `cloneVariable()` and `autoRecode()` now allow automatic appending of variable label suffixes via the `label_suffix` argument

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -15,3 +15,13 @@ check_vars_in_GADSdat <- function(GADSdat, vars) {
   return()
 }
 
+check_vars_in_vector <- function(vec, vars, vec_nam) {
+  dup_vars <- vars[duplicated(vars)]
+  if(length(dup_vars) > 0) stop("There are duplicates in 'vars': ",
+                                paste(dup_vars, collapse = ", "))
+
+  other_vars <- vars[!vars %in% vec]
+  if(length(other_vars) > 0) stop("The following 'vars' are not variables in the ", vec_nam, ": ",
+                                  paste(other_vars, collapse = ", "))
+  return()
+}

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -50,14 +50,22 @@
 #'                           labels2factor = c("migration"))
 #'
 #'@export
-extractData2 <- function(GADSdat, convertMiss = TRUE, labels2character = NULL, labels2factor = NULL,
-                         labels2ordered = NULL, dropPartialLabels = TRUE) {
+extractData2 <- function(GADSdat,
+                         convertMiss = TRUE,
+                         labels2character = NULL,
+                         labels2factor = NULL,
+                         labels2ordered = NULL,
+                         dropPartialLabels = TRUE) {
   UseMethod("extractData2")
 }
 
 #'@export
-extractData2.GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character = NULL, labels2factor = NULL,
-                                 labels2ordered = NULL, dropPartialLabels = TRUE) {
+extractData2.GADSdat <- function(GADSdat,
+                                 convertMiss = TRUE,
+                                 labels2character = NULL,
+                                 labels2factor = NULL,
+                                 labels2ordered = NULL,
+                                 dropPartialLabels = TRUE) {
   check_GADSdat(GADSdat)
   # input validation
   if(!is.null(labels2character)) check_vars_in_GADSdat(GADSdat, labels2character)
@@ -92,8 +100,12 @@ extractData2.GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character =
 }
 
 #'@export
-extractData2.trend_GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character = NULL, labels2factor = NULL,
-                                       labels2ordered = NULL, dropPartialLabels = TRUE) {
+extractData2.trend_GADSdat <- function(GADSdat,
+                                       convertMiss = TRUE,
+                                       labels2character = NULL,
+                                       labels2factor = NULL,
+                                       labels2ordered = NULL,
+                                       dropPartialLabels = TRUE) {
   # Input validation
   check_trend_GADSdat(GADSdat)
   if(!is.null(labels2character) && !is.character(labels2character)) stop("'labels2character' must be a character vector.")

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -28,7 +28,7 @@
 #'are of type \code{ordered}.
 #'@param dropPartialLabels Should value labels for partially labeled variables be dropped?
 #'If \code{TRUE}, the partial labels will be dropped. If \code{FALSE}, the variable will be converted
-#'to the class specified in \code{convertLabels}.
+#'to the class specified in \code{labels2character}, \code{labels2factor}, or \code{labels2ordered}.
 #'
 #'@return Returns a data frame.
 #'
@@ -92,9 +92,19 @@ extractData2.GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character =
 }
 
 #'@export
-extractData2.trend_GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character = namesGADS(GADSdat), labels2factor = NULL,
+extractData2.trend_GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character = NULL, labels2factor = NULL,
                                        labels2ordered = NULL, dropPartialLabels = TRUE) {
-  stop("extractData2 has not been implemented for 'trend_GADSdat' objects.")
+  check_trend_GADSdat(GADSdat)
+
+  dat_list <- lapply(names(GADSdat$datList), function(nam) {
+    gads <- extractGADSdat(all_GADSdat = GADSdat, name = nam)
+    dat <- extractData2(gads, convertMiss = convertMiss, labels2character = labels2character, labels2factor = labels2factor,
+                       labels2ordered = labels2ordered, dropPartialLabels = dropPartialLabels)
+    dat
+  })
+
+  dat_out <- do.call(plyr::rbind.fill, dat_list)
+  dat_out[, c(setdiff(names(dat_out), "year"), "year")]
 }
 
 

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -94,12 +94,25 @@ extractData2.GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character =
 #'@export
 extractData2.trend_GADSdat <- function(GADSdat, convertMiss = TRUE, labels2character = NULL, labels2factor = NULL,
                                        labels2ordered = NULL, dropPartialLabels = TRUE) {
+  # Input validation
   check_trend_GADSdat(GADSdat)
+  if(!is.null(labels2character) && !is.character(labels2character)) stop("'labels2character' must be a character vector.")
+  if(!is.null(labels2factor) && !is.character(labels2factor)) stop("'labels2factor' must be a character vector.")
+  if(!is.null(labels2ordered) && !is.character(labels2ordered)) stop("'labels2ordered' must be a character vector.")
+  all_GADSdat_names <- unique(unlist(namesGADS(GADSdat)))
+  check_vars_in_vector(all_GADSdat_names, vars = labels2character, vec_nam = "GADSdats")
+  check_vars_in_vector(all_GADSdat_names, vars = labels2factor, vec_nam = "GADSdats")
+  check_vars_in_vector(all_GADSdat_names, vars = labels2ordered, vec_nam = "GADSdats")
 
   dat_list <- lapply(names(GADSdat$datList), function(nam) {
     gads <- extractGADSdat(all_GADSdat = GADSdat, name = nam)
-    dat <- extractData2(gads, convertMiss = convertMiss, labels2character = labels2character, labels2factor = labels2factor,
-                       labels2ordered = labels2ordered, dropPartialLabels = dropPartialLabels)
+
+    single_labels2character <- labels2character[labels2character %in% namesGADS(gads)]
+    single_labels2factor <- labels2factor[labels2factor %in% namesGADS(gads)]
+    single_labels2ordered <- labels2ordered[labels2ordered %in% namesGADS(gads)]
+
+    dat <- extractData2(gads, convertMiss = convertMiss, labels2character = single_labels2character, labels2factor = single_labels2factor,
+                       labels2ordered = single_labels2ordered, dropPartialLabels = dropPartialLabels)
     dat
   })
 
@@ -113,7 +126,7 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
   if(is.null(labels2character) && is.null(labels2factor)) return(dat)
   # Which variables should their value labels be applied to?
   convertVariables <- c(labels2character, labels2factor, labels2ordered)
-  stopifnot(is.character(convertVariables) && length(convertVariables) > 0)
+  #stopifnot(is.character(convertVariables) && length(convertVariables) > 0)
 
   change_labels <- labels[labels[, "varName"] %in% convertVariables, ]    # careful, from here use only change_labels!
   # check value labels, remove incomplete labels from insertion to protect variables

--- a/man/extractData2.Rd
+++ b/man/extractData2.Rd
@@ -29,7 +29,7 @@ are of type \code{ordered}.}
 
 \item{dropPartialLabels}{Should value labels for partially labeled variables be dropped?
 If \code{TRUE}, the partial labels will be dropped. If \code{FALSE}, the variable will be converted
-to the class specified in \code{convertLabels}.}
+to the class specified in \code{labels2character}, \code{labels2factor}, or \code{labels2ordered}.}
 }
 \value{
 Returns a data frame.

--- a/tests/testthat/test_check_functions.R
+++ b/tests/testthat/test_check_functions.R
@@ -20,3 +20,12 @@ test_that("check_vars_in_GADSdat", {
   expect_error(check_vars_in_GADSdat(dfSAV, vars = c("VAR4", "VAR6")),
                "The following 'vars' are not variables in the GADSdat: VAR4, VAR6")
 })
+
+test_that("check_vars_in_vec", {
+  expect_error(check_vars_in_vector(namesGADS(dfSAV), vars = c("VAR1", "VAR1"), vec_nam = "GADSdat"),
+               "There are duplicates in 'vars': VAR1")
+  expect_error(check_vars_in_vector(namesGADS(dfSAV), vars = c("VAR4"), vec_nam = "GADSdat"),
+               "The following 'vars' are not variables in the GADSdat: VAR4")
+  expect_error(check_vars_in_vector(dfSAV, vars = c("VAR4", "VAR6"), vec_nam = "GADSdats"),
+               "The following 'vars' are not variables in the GADSdats: VAR4, VAR6")
+})

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -198,6 +198,42 @@ test_that("extractData2 with some variables labels applied to (convertVariables 
                           b = c(2, 1), stringsAsFactors = TRUE))
 })
 
+test_that("Extract data trend GADS", {
+  # trend_gads <- getTrendGADS(filePaths = c("tests/testthat/helper_dataBase.db", "tests/testthat/helper_dataBase_uniqueVar.db"), years = c(2012, 2018), fast = FALSE)
+  trend_gads <- suppressWarnings(getTrendGADS(filePaths = c("helper_dataBase.db", "helper_dataBase_uniqueVar.db"),
+                                              years = c(2012, 2018), fast = FALSE, verbose = FALSE))
+  out <- extractData2(trend_gads)
+  expect_equal(dim(out), c(6, 5))
+  expect_equal(names(out), c("ID1", "V1", "V2", "V3", "year"))
+  comp <- c(rep(2012, 3), c(rep(2018, 3)))
+  attr(comp, "label") <- "Trendvariable, indicating the year of the assessment"
+  expect_equal(out$year, comp)
+
+  ## convertVariables if some variables are not in both GADS
+  out2 <- extractData(trend_gads, convertVariables = "V3")
+  expect_equal(out, out2)
+})
+
+
+test_that("Extract data trend GADS 3 MPs", {
+  fp1 <- system.file("extdata", "trend_gads_2020.db", package = "eatGADS")
+  fp2 <- system.file("extdata", "trend_gads_2015.db", package = "eatGADS")
+  fp3 <- system.file("extdata", "trend_gads_2010.db", package = "eatGADS")
+  s <- capture_output(gads_3mp <- getTrendGADS(filePaths = c(fp1, fp2, fp3), years = c(2020, 2015, 2010), fast = FALSE, verbose = FALSE))
+
+  out <- extractData2(gads_3mp)
+  expect_equal(dim(out), c(180, 10))
+  expect_equal(dim(out), c(180, 10))
+  expect_equal(names(out), c("idstud", "gender", "dimension", "imp", "score", "traitLevel", "failMin", "passReg", "passOpt", "year"))
+  expect_equal(out$dimension[1:2], c(1, 2))
+  expect_equal(as.numeric(out$year), c(rep(2020, 60), rep(2015, 60), rep(2010, 60)))
+
+  out2 <- extractData2(gads_3mp, labels2character = "dimension")
+  expect_equal(out2$dimension[1:2], c("listening", "reading"))
+
+  out3 <- extractData2(gads_3mp, labels2factor = "dimension")
+  expect_equal(out3$dimension[1:2], factor(c("listening", "reading")))
+})
 
 
 

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -198,6 +198,25 @@ test_that("extractData2 with some variables labels applied to (convertVariables 
                           b = c(2, 1), stringsAsFactors = TRUE))
 })
 
+test_that("Spefific trend GADS errors", {
+  # trend_gads <- getTrendGADS(filePaths = c("tests/testthat/helper_dataBase.db", "tests/testthat/helper_dataBase_uniqueVar.db"), years = c(2012, 2018), fast = FALSE)
+  trend_gads <- suppressWarnings(getTrendGADS(filePaths = c("helper_dataBase.db", "helper_dataBase_uniqueVar.db"),
+                                              years = c(2012, 2018), fast = FALSE, verbose = FALSE))
+  expect_error(extractData2(trend_gads, labels2character = list("v5")),
+               "'labels2character' must be a character vector.")
+  expect_error(extractData2(trend_gads, labels2factor = list("v5")),
+               "'labels2factor' must be a character vector.")
+  expect_error(extractData2(trend_gads, labels2ordered = list("v5")),
+               "'labels2ordered' must be a character vector.")
+
+  expect_error(extractData2(trend_gads, labels2character = c("v5", "v3")),
+               "The following 'vars' are not variables in the GADSdats: v5")
+  expect_error(extractData2(trend_gads, labels2factor = c("v5", "v3")),
+               "The following 'vars' are not variables in the GADSdats: v5")
+  expect_error(extractData2(trend_gads, labels2ordered = c("v5", "v3")),
+               "The following 'vars' are not variables in the GADSdats: v5")
+})
+
 test_that("Extract data trend GADS", {
   # trend_gads <- getTrendGADS(filePaths = c("tests/testthat/helper_dataBase.db", "tests/testthat/helper_dataBase_uniqueVar.db"), years = c(2012, 2018), fast = FALSE)
   trend_gads <- suppressWarnings(getTrendGADS(filePaths = c("helper_dataBase.db", "helper_dataBase_uniqueVar.db"),
@@ -210,7 +229,7 @@ test_that("Extract data trend GADS", {
   expect_equal(out$year, comp)
 
   ## convertVariables if some variables are not in both GADS
-  out2 <- extractData(trend_gads, convertVariables = "V3")
+  out2 <- extractData2(trend_gads, labels2character = "V3")
   expect_equal(out, out2)
 })
 

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -228,9 +228,14 @@ test_that("Extract data trend GADS", {
   attr(comp, "label") <- "Trendvariable, indicating the year of the assessment"
   expect_equal(out$year, comp)
 
-  ## convertVariables if some variables are not in both GADS
-  out2 <- extractData2(trend_gads, labels2character = "V3")
-  expect_equal(out, out2)
+  ## convertVariables if some variables are not in both GADS and value labels are applied
+  trend_gads2 <- trend_gads
+  trend_gads2$allLabels <- trend_gads2$allLabels[c(1:6, 7, 7, 8:9), ]
+  trend_gads2$allLabels[7:8, "value"] <- 8:9
+  trend_gads2$allLabels[7:8, "valLabel"] <- c("yes", "no")
+  trend_gads2$allLabels[7:8, "labeled"] <- "yes"
+  out2 <- extractData2(trend_gads2, labels2character = "V3")
+  expect_equal(out2$V3, c(NA, NA, NA, "yes", "yes", "no"))
 })
 
 
@@ -244,14 +249,14 @@ test_that("Extract data trend GADS 3 MPs", {
   expect_equal(dim(out), c(180, 10))
   expect_equal(dim(out), c(180, 10))
   expect_equal(names(out), c("idstud", "gender", "dimension", "imp", "score", "traitLevel", "failMin", "passReg", "passOpt", "year"))
-  expect_equal(out$dimension[1:2], c(1, 2))
+  expect_equal(out$dimension, rep(c(1, 2), 90))
   expect_equal(as.numeric(out$year), c(rep(2020, 60), rep(2015, 60), rep(2010, 60)))
 
   out2 <- extractData2(gads_3mp, labels2character = "dimension")
-  expect_equal(out2$dimension[1:2], c("listening", "reading"))
+  expect_equal(out2$dimension, rep(c("listening", "reading"), 90))
 
   out3 <- extractData2(gads_3mp, labels2factor = "dimension")
-  expect_equal(out3$dimension[1:2], factor(c("listening", "reading")))
+  expect_equal(out3$dimension, factor(rep(c("listening", "reading"), 90)))
 })
 
 

--- a/vignettes/getGADS.Rmd
+++ b/vignettes/getGADS.Rmd
@@ -70,26 +70,33 @@ extractMeta(db_path, c("idstud", "schtype"))
 To extract a data set from the data base, we can use the function `getGADS()`. If the data base is stored on a server drive, `getGADS_fast()` provides identical functionality but substantially increases the performance. With the `vSelect` argument we specify our variable selection. It is important to note that `getGADS()` returns a so called `GADSdat` object. This object type contains complex meta information (that is for example also available in a `SPSS` data set), and is therefore not directly usable for data analysis. We can, however, use the `extractMeta()` function on it to access the meta data.     
 
 ```{r getGADS}
-gads1 <- getGADS(filePath = db_path, vSelect = c("idstud", "schtype"))
+gads1 <- getGADS(filePath = db_path, vSelect = c("idstud", "schtype", "gender"))
 class(gads1)
 extractMeta(gads1)
 ```
 
 ## Extract data from `GADSdat`
 
-If we want to use the data for analyses in `R` we have to extract it from the `GADSdat` object via the function `extractData()`. In doing so, we have to make two important decisions: (a) how should values marked as missing values be treated (`convertMiss`)? And (b) how should labeled values in general be treated (`convertLabels`, `dropPartialLabels`, `convertVariables`)? See `?extractData` for more details.
+If we want to use the data for analyses in `R` we have to extract it from the `GADSdat` object via the function `extractData2()`. In doing so, we have to make two important decisions: (a) how should values marked as missing values be treated (`convertMiss`)? And (b) how should labeled values in general be treated (`labels2character`, `labels2factor`, `labels2ordered`, and `dropPartialLabels`)? 
+
+Per default, all missing tags are applied, meaning all values tagged as missing are recoded to `NA` (`convertMiss == TRUE`). Furthermore, per default, all value labels are dropped (`labels2character = NULL`, `labels2factor = NULL`, `labels2ordered = NULL`). If for specific variables, value labels should be applied and the resulting variable should be a character variable, this can specified via, for example, setting `labels2character = c("var1", "var2")`. 
 
 ```{r extractdata}
-## convert labeled variables to characters
-dat1 <- extractData(gads1, convertLabels = "character")
+## leave all labeled variables as numeric, convert missings to NA
+dat1 <- extractData2(gads1)
 head(dat1)
 
-## leave labeled variables as numeric
-dat2 <- extractData(gads1, convertLabels = "numeric")
+## convert selected labeled variable(s) to character, convert missings to NA
+dat2 <- extractData2(gads1, labels2character = c("schtype"))
 head(dat2)
+
+## convert all labeled variables to character, convert missings to NA
+dat3 <- extractData2(gads1, labels2character = namesGADS(gads1))
+head(dat3)
+
 ```
 
-In general, we recommend leaving labeled variables as numeric and converting values with missing codes to `NA`. The latter is the default behavior for the argument `checkMissings`. If required, values labels can always be accessed via using `extractMeta()` on the `GADSdat` object or the data base.
+In general, we recommend leaving labeled variables as numeric and converting values with missing codes to `NA`. If required, values labels can always be accessed via using `extractMeta()` on the `GADSdat` object or the data base.
 
 ## Selecting different hierarchy levels
 
@@ -99,7 +106,7 @@ The function `getGADS()` extracts data automatically in the appropriate structur
 
 ```{r noImp hierarchy levels}
 gads1 <- getGADS(db_path, vSelect = c("schtype", "g8g9"))
-dat1 <- extractData(gads1)
+dat1 <- extractData2(gads1)
 dim(dat1)
 head(dat1)
 ```
@@ -108,7 +115,7 @@ If additionally variables from the plausible Value data table are extracted, the
 
 ```{r PVs hierarchy levels}
 gads2 <- getGADS(db_path, vSelect = c("schtype", "value"))
-dat2 <- extractData(gads2)
+dat2 <- extractData2(gads2)
 dim(dat2)
 head(dat2)
 ```
@@ -131,7 +138,7 @@ trend_path3 <- system.file("extdata", "trend_gads_2010.db", package = "eatGADS")
 gads_trend <- getTrendGADS(filePaths = c(trend_path1, trend_path2, trend_path3), 
                            vSelect = c("idstud", "dimension", "score"), 
                            years = c(2020, 2015, 2010), fast = FALSE)
-dat_trend <- extractData(gads_trend)
+dat_trend <- extractData2(gads_trend)
 head(dat_trend)
 ```
 


### PR DESCRIPTION
Implements `extractData2()` S3 method for `trend_GADSdat` objects. Closes #29. 

Needed for tomorrows BT22 workshop. Sorry for the urgency!