### PR TITLE
input validation multichar2fac

### DIFF
--- a/R/multiChar2fac.R
+++ b/R/multiChar2fac.R
@@ -56,6 +56,10 @@ multiChar2fac.GADSdat <- function(GADSdat, vars, var_suffix = "_r", label_suffix
   check_GADSdat(GADSdat)
   if(!is.character(vars) && length(vars) > 0) stop("vars needs to be a character vector of at least length 1.")
   check_vars_in_GADSdat(GADSdat, vars)
+  all_content <- unlist(GADSdat$dat[, vars])
+  if(all(is.na(all_content))) {
+    stop("Variables in 'vars' contain only NAs. Transforming to factor is not meaningful.")
+  }
 
   ## current limitation: for multiple vars, meta data must be equal (maybe extend later?)
   if(length(vars) > 1) {

--- a/tests/testthat/test_multiChar2fac.R
+++ b/tests/testthat/test_multiChar2fac.R
@@ -16,10 +16,15 @@ mt4_gads_2$labels[1:2, c("labeled")] <- c("yes")
 mt4_gads_2$labels[1:2, c("missings")] <- c("miss")
 
 test_that("errors", {
-  mt4_gads_3 <- changeMissings(mt4_gads_2, "text2", value = -99, missings = "valid")
+  mt4_gads_4 <- mt4_gads_3 <- changeMissings(mt4_gads_2, "text2", value = -99, missings = "valid")
   expect_error(multiChar2fac(mt4_gads_3, vars = namesGADS(mt4_gads_2)),
                "Meta data on value level ('value', 'valLabel', 'missings') of variables 'text1' and 'text2' must be identical.",
                fixed = TRUE)
+  mt4_gads_4$dat[] <- NA
+  expect_error(multiChar2fac(mt4_gads_4, vars = namesGADS(mt4_gads_2)),
+               "Variables in 'vars' contain only NAs. Transforming to factor is not meaningful.")
+  expect_error(multiChar2fac(mt4_gads_4, vars = "text1"),
+               "Variables in 'vars' contain only NAs. Transforming to factor is not meaningful.")
 })
 
 


### PR DESCRIPTION
Added input validation (do variables contain only `NAs`) for `multiChar2fac()`. More input validation (for other arguments) would be nice but I realized too late that the new check-functions are only in the other pull request.

Closes #38 