### PR TITLE
updateMeta() compatability with extractData()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* `updateMeta()` is now compatible with `extractData()` and `extractData2()`
 * S3 method of `extractData2()` now available for `trend_GADSdat` objects
 * `recodeGADS()` and `applyChangeMeta()` allow recoding values without recoding value labels (via `existingMeta = "ignore"`)
 * `insertVariable()` has been renamed `relocateVariable()` for clarity. Variables can now be inserted at the very beginning of a `GADSdat`

--- a/R/updateMeta.R
+++ b/R/updateMeta.R
@@ -38,6 +38,9 @@ updateMeta.GADSdat <- function(GADSdat, newDat) {
   ## replace variables that have been imported newly
   newDat[, names(addData[["dat"]])] <- addData[["dat"]]
 
+  # drop additional attributes from data
+  newDat[] <- lapply(newDat, c)
+
   mod_GADSdat <- new_GADSdat(dat = newDat, labels = labels)
   check_GADSdat(mod_GADSdat)
   mod_GADSdat

--- a/tests/testthat/test_updateMeta.R
+++ b/tests/testthat/test_updateMeta.R
@@ -2,6 +2,10 @@
 # load(file = "tests/testthat/helper_data.rda")
 load(file = "helper_data.rda")
 
+# dfSAV <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
+dfSAV <- import_spss(file = "helper_spss_missings.sav")
+
+
 ### Update Meta
 newDat <- df1$dat
 newDat$v3 <- c(4, 5)
@@ -57,4 +61,11 @@ test_that("illegal variable names", {
   mess <- capture_messages(out_both <- updateMeta(df1, newDat_ill))
   expect_equal(mess[2], "Alter has been renamed to AlterVar\n")
   expect_equal(names(out_both$dat), c("ID1", "V1", "AlterVar"))
+})
+
+test_that("updateMeta extractData combination", {
+  suppressWarnings(newDat_ill <- extractData2(dfSAV, labels2character = namesGADS(dfSAV), dropPartialLabels = FALSE))
+  suppressMessages(out_both <- updateMeta(dfSAV, newDat_ill))
+  expect_equal(attr(out_both$dat[[1]], "label"), NULL)
+  expect_equal(attr(out_both$dat[[3]], "label"), NULL)
 })


### PR DESCRIPTION
Originally `updateMeta()` preserved variable labels in `newDat` as produced by `extractData()` and `extractData2()`. Now `updateMeta()` drops all attributes on variable level from `newDat`. This prevents issues, for instance, with `inspectDifferences()`.