### PR TITLE
recode2NA for multiple values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* `recode2NA()` now allows the recoding of multiple `values` at once and returns a warning, if the recoded values have existing value labels in the recoded variables
 * `updateMeta()` is now compatible with `extractData()` and `extractData2()`
 * S3 method of `extractData2()` now available for `trend_GADSdat` objects
 * `recodeGADS()` and `applyChangeMeta()` allow recoding values without recoding value labels (via `existingMeta = "ignore"`)

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -4,13 +4,13 @@ check_single_varName <- function(var, argumentName = "varName") {
 }
 
 
-check_vars_in_GADSdat <- function(GADSdat, vars) {
+check_vars_in_GADSdat <- function(GADSdat, vars, argName = "vars") {
   dup_vars <- vars[duplicated(vars)]
-  if(length(dup_vars) > 0) stop("There are duplicates in 'vars': ",
+  if(length(dup_vars) > 0) stop("There are duplicates in '", argName,"': ",
                                 paste(dup_vars, collapse = ", "))
 
   other_vars <- vars[!vars %in% namesGADS(GADSdat)]
-  if(length(other_vars) > 0) stop("The following 'vars' are not variables in the GADSdat: ",
+  if(length(other_vars) > 0) stop("The following '", argName,"' are not variables in the GADSdat: ",
                                   paste(other_vars, collapse = ", "))
   return()
 }

--- a/R/recode2NA.R
+++ b/R/recode2NA.R
@@ -1,10 +1,10 @@
 
 #############################################################################
-#' Recode a value to \code{NA}.
+#' Recode values to \code{NA}.
 #'
-#' Recode a value in multiple variables in a \code{GADSdat} to \code{NA}.
+#' Recode multiple values in multiple variables in a \code{GADSdat} to \code{NA}.
 #'
-#' If there are value labels given to the specified value, these are removed. Number of recodes per variable are reported.
+#' If there are value labels given to the specified value, a warning is issued. Number of recodes per variable are reported.
 #'
 #' If a data set is imported from \code{.sav} character variables frequently contain empty strings. Especially if parts of the
 #' data are written to \code{.xlsx} this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
@@ -13,7 +13,7 @@
 #'
 #'@param GADSdat A \code{GADSdat} object.
 #'@param recodeVars Character vector of variable names which should be recoded.
-#'@param value Which value should be recoded to \code{NA}?
+#'@param value Which values should be recoded to \code{NA}?
 #'
 #'@return Returns the recoded \code{GADSdat}.
 #'
@@ -28,7 +28,7 @@
 #' gads2 <- recode2NA(gads)
 #'
 #' # recode numeric value
-#' gads3 <- recode2NA(gads, recodeVars = "ID", value = 1)
+#' gads3 <- recode2NA(gads, recodeVars = "ID", value = 1:3)
 #'
 #'
 #'@export
@@ -40,15 +40,18 @@ recode2NA <- function(GADSdat, recodeVars = namesGADS(GADSdat), value = "") {
 recode2NA.GADSdat <- function(GADSdat, recodeVars = namesGADS(GADSdat), value = "") {
   check_GADSdat(GADSdat)
   if(!is.character(recodeVars) || length(recodeVars) < 1) stop("'recodeVars' needs to be character vector of at least length 1.")
-  if(!all(recodeVars %in% namesGADS(GADSdat))) stop("All variables names in 'recodeVars' need to be variables in the GADSdat.")
-  if(!is.vector(value) || length(value) != 1) stop("'value' needs to be a vector of exactly length 1.")
+  check_vars_in_GADSdat(GADSdat, vars = recodeVars)
+  if(!is.vector(value) || length(value) == 0) stop("'value' needs to be a vector of at least length 1.")
 
-  if(length(which(GADSdat$labels[GADSdat$labels$varName %in% recodeVars, "value"] == value)) > 0) {
-   # stop("'string' is labeled in at least one of the recodeVars.")
+  labeled_values <- GADSdat$labels[GADSdat$labels$varName %in% recodeVars, c("varName", "value")]
+  labeled_values_recode <- unique(labeled_values[which(labeled_values$value %in% value), "varName"])
+  if(length(labeled_values_recode) > 0) {
+   warning("Some 'value' is labeled in the following variables in 'recodeVars': ",
+        paste(labeled_values_recode, collapse = ", "))
   }
 
   for(recodeVar in recodeVars) {
-    log_vec <- which(GADSdat[["dat"]][, recodeVar] == value)
+    log_vec <- which(GADSdat[["dat"]][, recodeVar] %in% value)
     GADSdat[["dat"]][log_vec, recodeVar] <- NA
     message("Recodes in variable ", recodeVar, ": ", length(log_vec))
   }

--- a/R/recode2NA.R
+++ b/R/recode2NA.R
@@ -6,8 +6,8 @@
 #'
 #' If there are value labels given to the specified value, a warning is issued. Number of recodes per variable are reported.
 #'
-#' If a data set is imported from \code{.sav} character variables frequently contain empty strings. Especially if parts of the
-#' data are written to \code{.xlsx} this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
+#' If a data set is imported from \code{.sav}, character variables frequently contain empty strings. Especially if parts of the
+#' data are written to \code{.xlsx}, this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
 #' as most function which write to \code{.xlsx} convert empty strings to \code{NAs}. \code{recodeString2NA} can be
 #' used to recode all empty strings to \code{NA} beforehand.
 #'
@@ -39,9 +39,13 @@ recode2NA <- function(GADSdat, recodeVars = namesGADS(GADSdat), value = "") {
 #'@export
 recode2NA.GADSdat <- function(GADSdat, recodeVars = namesGADS(GADSdat), value = "") {
   check_GADSdat(GADSdat)
-  if(!is.character(recodeVars) || length(recodeVars) < 1) stop("'recodeVars' needs to be character vector of at least length 1.")
-  check_vars_in_GADSdat(GADSdat, vars = recodeVars)
-  if(!is.vector(value) || length(value) == 0) stop("'value' needs to be a vector of at least length 1.")
+  if(!is.character(recodeVars) || length(recodeVars) < 1) {
+    stop("'recodeVars' needs to be character vector of at least length 1.")
+  }
+  check_vars_in_GADSdat(GADSdat, vars = recodeVars, argName = "recodeVars")
+  if(!is.vector(value) || length(value) == 0) {
+    stop("'value' needs to be a vector of at least length 1.")
+  }
 
   labeled_values <- GADSdat$labels[GADSdat$labels$varName %in% recodeVars, c("varName", "value")]
   labeled_values_recode <- unique(labeled_values[which(labeled_values$value %in% value), "varName"])

--- a/man/recode2NA.Rd
+++ b/man/recode2NA.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/recode2NA.R
 \name{recode2NA}
 \alias{recode2NA}
-\title{Recode a value to \code{NA}.}
+\title{Recode values to \code{NA}.}
 \usage{
 recode2NA(GADSdat, recodeVars = namesGADS(GADSdat), value = "")
 }
@@ -11,16 +11,16 @@ recode2NA(GADSdat, recodeVars = namesGADS(GADSdat), value = "")
 
 \item{recodeVars}{Character vector of variable names which should be recoded.}
 
-\item{value}{Which value should be recoded to \code{NA}?}
+\item{value}{Which values should be recoded to \code{NA}?}
 }
 \value{
 Returns the recoded \code{GADSdat}.
 }
 \description{
-Recode a value in multiple variables in a \code{GADSdat} to \code{NA}.
+Recode multiple values in multiple variables in a \code{GADSdat} to \code{NA}.
 }
 \details{
-If there are value labels given to the specified value, these are removed. Number of recodes per variable are reported.
+If there are value labels given to the specified value, a warning is issued. Number of recodes per variable are reported.
 
 If a data set is imported from \code{.sav} character variables frequently contain empty strings. Especially if parts of the
 data are written to \code{.xlsx} this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
@@ -38,7 +38,7 @@ gads <- import_DF(dat)
 gads2 <- recode2NA(gads)
 
 # recode numeric value
-gads3 <- recode2NA(gads, recodeVars = "ID", value = 1)
+gads3 <- recode2NA(gads, recodeVars = "ID", value = 1:3)
 
 
 }

--- a/man/recode2NA.Rd
+++ b/man/recode2NA.Rd
@@ -22,8 +22,8 @@ Recode multiple values in multiple variables in a \code{GADSdat} to \code{NA}.
 \details{
 If there are value labels given to the specified value, a warning is issued. Number of recodes per variable are reported.
 
-If a data set is imported from \code{.sav} character variables frequently contain empty strings. Especially if parts of the
-data are written to \code{.xlsx} this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
+If a data set is imported from \code{.sav}, character variables frequently contain empty strings. Especially if parts of the
+data are written to \code{.xlsx}, this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
 as most function which write to \code{.xlsx} convert empty strings to \code{NAs}. \code{recodeString2NA} can be
 used to recode all empty strings to \code{NA} beforehand.
 }

--- a/tests/testthat/test_checkValLabels.R
+++ b/tests/testthat/test_checkValLabels.R
@@ -115,7 +115,7 @@ test_that("checkMissingValLabels data.frame", {
 
 
 test_that("With NAs", {
-  suppressMessages(dfSAV2 <- recode2NA(dfSAV, value = 1))
+  suppressMessages(suppressWarnings(dfSAV2 <- recode2NA(dfSAV, value = 1)))
   out <- checkEmptyValLabels(dfSAV2)
   expect_equal(out[[2]], checkEmptyValLabels(dfSAV)[[2]])
   expect_equal(out[[3]], checkEmptyValLabels(dfSAV)[[3]])

--- a/tests/testthat/test_recode2NA.R
+++ b/tests/testthat/test_recode2NA.R
@@ -27,13 +27,18 @@ test_that("Recode2NA mixed data and missings in string", {
 
 
 test_that("Errors for Recode2NA", {
-  expect_error(out <- recode2NA(txt_gads, value = c("", "la")), "'value' needs to be a vector of exactly length 1.")
+  expect_error(out <- recode2NA(txt_gads, value = c()), "'value' needs to be a vector of at least length 1.")
   expect_error(out <- recode2NA(mt_gads, recodeVar = mtcars, value = c("1")), "'recodeVars' needs to be character vector of at least length 1.")
 })
 
 
 test_that("Recode2NA numerics", {
-  out <- recode2NA(dfSAV, recodeVars =  "VAR1", value = 1)
+  expect_warning(out <- recode2NA(dfSAV, recodeVars =  "VAR1", value = 1),
+                 "Some 'value' is labeled in the following variables in 'recodeVars': VAR1")
   expect_equal(out$dat$VAR1, c(NA, -99, -96, 2))
+
+  expect_warning(out <- recode2NA(dfSAV, recodeVars =  "VAR1", value = 1:2),
+                 "Some 'value' is labeled in the following variables in 'recodeVars': VAR1")
+  expect_equal(out$dat$VAR1, c(NA, -99, -96, NA))
 })
 

--- a/tests/testthat/test_recode2NA.R
+++ b/tests/testthat/test_recode2NA.R
@@ -23,12 +23,17 @@ test_that("Recode2NA mixed data and missings in string", {
   mess2 <- capture_messages(out <- recode2NA(mt_gads))
   expect_equal(out$dat$text, c(NA, NA, "Aus", "Aus2"))
   expect_equal(mess2[[3]], "Recodes in variable text: 1\n")
+
+  mess3 <- capture_messages(out2 <- recode2NA(mt_gads, value = c("", "Aus")))
+  expect_equal(out2$dat$text, c(NA, NA, NA, "Aus2"))
+  expect_equal(mess3[[3]], "Recodes in variable text: 2\n")
 })
 
 
 test_that("Errors for Recode2NA", {
-  expect_error(out <- recode2NA(txt_gads, value = c()), "'value' needs to be a vector of at least length 1.")
-  expect_error(out <- recode2NA(mt_gads, recodeVar = mtcars, value = c("1")), "'recodeVars' needs to be character vector of at least length 1.")
+  expect_error(recode2NA(txt_gads, value = c()), "'value' needs to be a vector of at least length 1.")
+  expect_error(recode2NA(mt_gads, recodeVar = 1, value = c("1")), "'recodeVars' needs to be character vector of at least length 1.")
+  expect_error(recode2NA(mt_gads, recodeVar = "test1", value = 1), "The following 'recodeVars' are not variables in the GADSdat: test1")
 })
 
 


### PR DESCRIPTION
`recode2NA()` only supported the recoding of a single `value` at once. Simple extension that closes #30 and adds more extensive reporting of existing value labels via warnings.