### PR TITLE
Inspect meta differences

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* `inspectMetaDifferences()` now can be applied to data bases as well
 * `recodeNA2missing()` for recoding `NAs` to a specific missing code
 * `recode2NA()` now allows the recoding of multiple `values` at once and returns a warning, if the recoded values have existing value labels in the recoded variables
 * `updateMeta()` is now compatible with `extractData()` and `extractData2()`

--- a/R/checkTrendStructure.R
+++ b/R/checkTrendStructure.R
@@ -8,6 +8,8 @@
 #' An error is thrown if the key structure or the data table structure differs between the two data bases. Differences regarding
 #' meta data for missing value labels and for variables labels (and formatting) are ignored.
 #'
+#' Reported differences regarding meta data can be inspected further via \code{\link{inspectMetaDifferences}}.
+#'
 #'@param filePath1 Path of the first \code{eatGADS} \code{.db} file.
 #'@param filePath2 Path of the second \code{eatGADS} \code{.db} file.
 #'

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -4,13 +4,15 @@ check_single_varName <- function(var, argumentName = "varName") {
 }
 
 
-check_vars_in_GADSdat <- function(GADSdat, vars, argName = "vars") {
+check_vars_in_GADSdat <- function(GADSdat, vars, argName = "vars", GADSdatName = "GADSdat") {
   dup_vars <- vars[duplicated(vars)]
   if(length(dup_vars) > 0) stop("There are duplicates in '", argName,"': ",
                                 paste(dup_vars, collapse = ", "))
 
-  other_vars <- vars[!vars %in% namesGADS(GADSdat)]
-  if(length(other_vars) > 0) stop("The following '", argName,"' are not variables in the GADSdat: ",
+  nams <- namesGADS(GADSdat)
+  if(is.list(nams)) nams <- unlist(nams)
+  other_vars <- vars[!vars %in% nams]
+  if(length(other_vars) > 0) stop("The following '", argName,"' are not variables in the ", GADSdatName, ": ",
                                   paste(other_vars, collapse = ", "))
   return()
 }

--- a/R/equalGADS.R
+++ b/R/equalGADS.R
@@ -1,9 +1,12 @@
 
 #############################################################################
-#' Test if Two \code{GADSdat} Objects are (Nearly) Equal
+#' Test if two \code{GADSdat} objects are (nearly) equal
 #'
 #' Run tests to check whether two \code{GADSdat} objects are (nearly) equal. Variable names, number of rows in the data,
 #' meta data and data differences are checked and reported as a list output.
+#'
+#' More detailed checks for individual variables can be performed via \code{\link{inspectDifferences}}
+#' and \code{\link{inspectMetaDifferences}}.
 #'
 #'@param target A \code{GADSdat} object.
 #'@param current A \code{GADSdat} object.

--- a/R/inspectDifferences.R
+++ b/R/inspectDifferences.R
@@ -5,8 +5,8 @@
 #' Inspect differences between two \code{GADSdat} objects in a specific variable.
 #'
 #' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
-#' If differences in the data are indicated for specific variables,
-#' these variables can be further inspected using \code{inspectDifferences}. Differences in meta data can be inspected via
+#' If differences in the data for specific variables in the two objects occur,
+#' these variables can be further inspected using \code{inspectDifferences}. Differences on meta data-level can be inspected via
 #' \code{\link{inspectMetaDifferences}}.
 #'
 #'@param varName A character vector of length 1 containing the variable name.

--- a/R/inspectDifferences.R
+++ b/R/inspectDifferences.R
@@ -4,8 +4,10 @@
 #'
 #' Inspect differences between two \code{GADSdat} objects in a specific variable.
 #'
-#' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}. If differences in the data are indicated for specific variables,
-#' these variables can be further inspected using \code{inspectDifferences}.
+#' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
+#' If differences in the data are indicated for specific variables,
+#' these variables can be further inspected using \code{inspectDifferences}. Differences in meta data can be inspected via
+#' \code{\link{inspectMetaDifferences}}.
 #'
 #'@param varName A character vector of length 1 containing the variable name.
 #'@param GADSdat1 A \code{GADSdat} object.

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -1,11 +1,13 @@
 ####
 #############################################################################
-#' Inspect differences in a variable.
+#' Inspect meta differences in a variable.
 #'
-#' Inspect differences between two \code{GADSdat} objects in a specific variable.
+#' Inspect meta differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
 #'
-#' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}. If differences in the meta data are indicated for specific variables,
+#' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
+#' If differences in the meta data are indicated for specific variables,
 #' these variables can be further inspected using \code{inspectMetaDifferences}.
+#' For differences on data level for a specific variable, see \code{\link{inspectDifferences}}.
 #'
 #'@param varName A character vector of length 1 containing the variable name.
 #'@param GADSdat1 A \code{GADSdat} object.
@@ -27,13 +29,10 @@
 #'
 #'@export
 inspectMetaDifferences <- function(varName, GADSdat1, GADSdat2) {
-  check_GADSdat(GADSdat1)
-  check_GADSdat(GADSdat2)
-  if(!is.character(varName) || length(varName) != 1) stop("'varName' must be a character of length 1.")
-  if(!varName %in% namesGADS(GADSdat1)) stop("'varName' is not a variable in 'GADSdat1'.")
-  if(!varName %in% namesGADS(GADSdat2)) stop("'varName' is not a variable in 'GADSdat2'.")
-
-  #if(isTRUE(all.equal(GADSdat2$dat[, varName], GADSdat1$dat[, varName], scale = 1))) return("all.equal")
+  check_characterArgument(varName, argName = "varName")
+  check_vars_in_GADSdat
+  if(!varName %in% unlist(namesGADS(GADSdat1))) stop("'varName' is not a variable in 'GADSdat1'.")
+  if(!varName %in% unlist(namesGADS(GADSdat2))) stop("'varName' is not a variable in 'GADSdat2'.")
 
   meta1 <- extractMeta(GADSdat1, varName)
   meta2 <- extractMeta(GADSdat2, varName)
@@ -44,7 +43,11 @@ inspectMetaDifferences <- function(varName, GADSdat1, GADSdat2) {
   row.names(metaVar1) <- row.names(metaVar2) <- NULL
 
   varDiff <- NULL
-  if(!identical(metaVar1, metaVar2)) varDiff <- data.frame(varName = varName, GADS1 = metaVar1[, 2:3], GADS2 = metaVar2[, 2:3])
+  if(!identical(metaVar1, metaVar2)) {
+    varDiff <- data.frame(varName = varName,
+                          GADS1 = metaVar1[, 2:3],
+                          GADS2 = metaVar2[, 2:3])
+  }
 
   ## Value level
   metaVal1 <- meta1[, c("varName", "value", "valLabel", "missings")]
@@ -65,7 +68,6 @@ inspectMetaDifferences <- function(varName, GADSdat1, GADSdat2) {
     }
     valDiff <- valDiff[order(valDiff$value), ]
   }
-
 
   list(varDiff = varDiff, valDiff = valDiff)
 }

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -1,13 +1,13 @@
 ####
 #############################################################################
-#' Inspect meta differences in a variable.
+#' Inspect meta data differences in a variable.
 #'
-#' Inspect meta differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
+#' Inspect meta data differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
 #'
 #' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
-#' If differences in the meta data are indicated for specific variables,
+#' If meta data differences for specific variables in the two objects occur,
 #' these variables can be further inspected using \code{inspectMetaDifferences}.
-#' For differences on data level for a specific variable, see \code{\link{inspectDifferences}}.
+#' For data-level differences for a specific variable, see \code{\link{inspectDifferences}}.
 #'
 #'@param varName A character vector of length 1 containing the variable name.
 #'@param GADSdat1 A \code{GADSdat} object.
@@ -30,9 +30,8 @@
 #'@export
 inspectMetaDifferences <- function(varName, GADSdat1, GADSdat2) {
   check_characterArgument(varName, argName = "varName")
-  check_vars_in_GADSdat
-  if(!varName %in% unlist(namesGADS(GADSdat1))) stop("'varName' is not a variable in 'GADSdat1'.")
-  if(!varName %in% unlist(namesGADS(GADSdat2))) stop("'varName' is not a variable in 'GADSdat2'.")
+  check_vars_in_GADSdat(GADSdat1, vars = varName, argName = "varName", GADSdatName = "GADSdat1")
+  check_vars_in_GADSdat(GADSdat2, vars = varName, argName = "varName", GADSdatName = "GADSdat2")
 
   meta1 <- extractMeta(GADSdat1, varName)
   meta2 <- extractMeta(GADSdat2, varName)

--- a/man/checkTrendStructure.Rd
+++ b/man/checkTrendStructure.Rd
@@ -21,4 +21,6 @@ these variables have the same value labels. Results of this comparison are repor
 \details{
 An error is thrown if the key structure or the data table structure differs between the two data bases. Differences regarding
 meta data for missing value labels and for variables labels (and formatting) are ignored.
+
+Reported differences regarding meta data can be inspected further via \code{\link{inspectMetaDifferences}}.
 }

--- a/man/equalGADS.Rd
+++ b/man/equalGADS.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/equalGADS.R
 \name{equalGADS}
 \alias{equalGADS}
-\title{Test if Two \code{GADSdat} Objects are (Nearly) Equal}
+\title{Test if two \code{GADSdat} objects are (nearly) equal}
 \usage{
 equalGADS(
   target,
@@ -27,4 +27,8 @@ Returns a list.
 \description{
 Run tests to check whether two \code{GADSdat} objects are (nearly) equal. Variable names, number of rows in the data,
 meta data and data differences are checked and reported as a list output.
+}
+\details{
+More detailed checks for individual variables can be performed via \code{\link{inspectDifferences}}
+and \code{\link{inspectMetaDifferences}}.
 }

--- a/man/inspectDifferences.Rd
+++ b/man/inspectDifferences.Rd
@@ -23,8 +23,8 @@ Inspect differences between two \code{GADSdat} objects in a specific variable.
 }
 \details{
 Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
-If differences in the data are indicated for specific variables,
-these variables can be further inspected using \code{inspectDifferences}. Differences in meta data can be inspected via
+If differences in the data for specific variables in the two objects occur,
+these variables can be further inspected using \code{inspectDifferences}. Differences on meta data-level can be inspected via
 \code{\link{inspectMetaDifferences}}.
 }
 \examples{

--- a/man/inspectDifferences.Rd
+++ b/man/inspectDifferences.Rd
@@ -22,8 +22,10 @@ A list.
 Inspect differences between two \code{GADSdat} objects in a specific variable.
 }
 \details{
-Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}. If differences in the data are indicated for specific variables,
-these variables can be further inspected using \code{inspectDifferences}.
+Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
+If differences in the data are indicated for specific variables,
+these variables can be further inspected using \code{inspectDifferences}. Differences in meta data can be inspected via
+\code{\link{inspectMetaDifferences}}.
 }
 \examples{
 # create a second GADS with different data

--- a/man/inspectMetaDifferences.Rd
+++ b/man/inspectMetaDifferences.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/inspectMetaDifferences.R
 \name{inspectMetaDifferences}
 \alias{inspectMetaDifferences}
-\title{Inspect meta differences in a variable.}
+\title{Inspect meta data differences in a variable.}
 \usage{
 inspectMetaDifferences(varName, GADSdat1, GADSdat2)
 }
@@ -17,13 +17,13 @@ inspectMetaDifferences(varName, GADSdat1, GADSdat2)
 A list.
 }
 \description{
-Inspect meta differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
+Inspect meta data differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
 }
 \details{
 Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
-If differences in the meta data are indicated for specific variables,
+If meta data differences for specific variables in the two objects occur,
 these variables can be further inspected using \code{inspectMetaDifferences}.
-For differences on data level for a specific variable, see \code{\link{inspectDifferences}}.
+For data-level differences for a specific variable, see \code{\link{inspectDifferences}}.
 }
 \examples{
 # create a second GADS with different meta data

--- a/man/inspectMetaDifferences.Rd
+++ b/man/inspectMetaDifferences.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/inspectMetaDifferences.R
 \name{inspectMetaDifferences}
 \alias{inspectMetaDifferences}
-\title{Inspect differences in a variable.}
+\title{Inspect meta differences in a variable.}
 \usage{
 inspectMetaDifferences(varName, GADSdat1, GADSdat2)
 }
@@ -17,11 +17,13 @@ inspectMetaDifferences(varName, GADSdat1, GADSdat2)
 A list.
 }
 \description{
-Inspect differences between two \code{GADSdat} objects in a specific variable.
+Inspect meta differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
 }
 \details{
-Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}. If differences in the meta data are indicated for specific variables,
+Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
+If differences in the meta data are indicated for specific variables,
 these variables can be further inspected using \code{inspectMetaDifferences}.
+For differences on data level for a specific variable, see \code{\link{inspectDifferences}}.
 }
 \examples{
 # create a second GADS with different meta data

--- a/tests/testthat/test_check_functions.R
+++ b/tests/testthat/test_check_functions.R
@@ -19,6 +19,9 @@ test_that("check_vars_in_GADSdat", {
                "The following 'vars' are not variables in the GADSdat: VAR4")
   expect_error(check_vars_in_GADSdat(dfSAV, vars = c("VAR4", "VAR6")),
                "The following 'vars' are not variables in the GADSdat: VAR4, VAR6")
+
+  expect_error(check_vars_in_GADSdat("helper_dataBase.db", vars = c("VAR4", "VAR6"), GADSdatName = "GADSdat1"),
+               "The following 'vars' are not variables in the GADSdat1: VAR4, VAR6")
 })
 
 test_that("check_vars_in_vec", {

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -6,6 +6,8 @@ test_that("Errors",{
   df1_5 <- df1_4 <- df1_2 <- df1_3 <- df1
   expect_error(inspectMetaDifferences(c("1", "2"), df1, df1_2),
                "'varName' needs to be a character vector of length 1.")
+  expect_error(inspectMetaDifferences("v1", df1, df1_2),
+               "The following 'varName' are not variables in the GADSdat1: v1")
 })
 
 test_that("Compare two identical GADSdat objects",{

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -5,13 +5,18 @@ load(file = "helper_data.rda")
 test_that("Errors",{
   df1_5 <- df1_4 <- df1_2 <- df1_3 <- df1
   expect_error(inspectMetaDifferences(c("1", "2"), df1, df1_2),
-               "'varName' must be a character of length 1.")
+               "'varName' needs to be a character vector of length 1.")
 })
 
 test_that("Compare two identical GADSdat objects",{
   out <- inspectMetaDifferences("V1", df1, df1)
   expect_null(out$varDiff)
   expect_null(out$valDiff)
+
+  out2 <- inspectMetaDifferences("V1", "helper_dataBase.db",
+                                "helper_dataBase.db")
+  expect_null(out2$varDiff)
+  expect_null(out2$valDiff)
 })
 
 test_that("Differences on variable level",{


### PR DESCRIPTION
`inspectMetaDifferences()` is extended to data bases. This is relevant if trend data bases are created which should be identical regarding meta data. Overall compatability can be tested using `checkTrendStructure()`; further inspection can then be performed by `inspectMetaDifferences()`.

This adresses #21. Extension to S3 generic is not necessary, as `extractMeta()` internally works with `GADSdat` objects and data bases.  