### PR TITLE
Missing tag conversion eatGADS to SPSS 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * new function `emptyTheseVariables()` allows setting multiple variables to `NA`
 
 ## bug fixes
+* `export_tibble()` and `write_spss()` now throw an error if a conversion of four or more discrete missing tags into a missing range leads to values in the data, which are not tagged as missing, being turned into missing tags
 * bug fix in `checkMissingsByValues()`, now correctly reports missing tags outside of the specified value range
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 * new function `emptyTheseVariables()` allows setting multiple variables to `NA`
 
 ## bug fixes
-* `export_tibble()` and `write_spss()` now throw an error if a conversion of four or more discrete missing tags into a missing range leads to values in the data, which are not tagged as missing, being turned into missing tags
+* `export_tibble()` and `write_spss()` now throw an error if a conversion of four or more discrete missing tags into a missing range has undesired side effects
 * bug fix in `checkMissingsByValues()`, now correctly reports missing tags outside of the specified value range
 
 

--- a/R/export_tibble.R
+++ b/R/export_tibble.R
@@ -6,7 +6,7 @@
 #' \code{haven}'s \code{\link[haven]{read_spss}} stores data together with meta data (e.g. value and variable labels) in a
 #' \code{tibble} with attributes on variable level. This function transforms a \code{GADSdat} object to such a \code{tibble}.
 #'
-#' This function is mainly intended for internal use.
+#' This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss}}.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
 #'
@@ -33,7 +33,8 @@ export_tibble.GADSdat <- function(GADSdat) {
     single_label_df <- label_df[label_df$varName == n, ]
     # add labels if any rows in label data frame
     if(nrow(single_label_df) > 0) {
-      attributes(df[, n]) <- addLabels_single(label_df = single_label_df, varClass = class(df[[n]]))
+      attributes(df[, n]) <- addLabels_single(varName = n, label_df = single_label_df,
+                                              raw_dat = df[[n]], varClass = class(df[[n]]))
     }
   }
   tibble::as_tibble(df)
@@ -51,53 +52,71 @@ check_var_type <- function(GADSdat) {
 
 
 ###  add labels to a single variable ---------------------------------------------------------
-addLabels_single <- function(label_df, varClass) {
-  out <- list()
+addLabels_single <- function(varName, label_df, raw_dat, varClass) {
+  attr_list <- list()
   # attributes on variable level
-  if(!all(is.na(label_df[, "varLabel"]))) out[["label"]] <- unique(label_df[, "varLabel"])
-  if(!all(is.na(label_df[, "format"]))) out[["format.spss"]] <- unique(label_df[, "format"])
-  if(!all(is.na(label_df[, "display_width"]))) out[["display_width"]] <- unique(label_df[, "display_width"])
+  if(!all(is.na(label_df[, "varLabel"]))) attr_list[["label"]] <- unique(label_df[, "varLabel"])
+  if(!all(is.na(label_df[, "format"]))) attr_list[["format.spss"]] <- unique(label_df[, "format"])
+  if(!all(is.na(label_df[, "display_width"]))) attr_list[["display_width"]] <- unique(label_df[, "display_width"])
   labeled <- unique(label_df[, "labeled"])
   # check
-  unique_attr <- unlist(lapply(out, length))
+  unique_attr <- unlist(lapply(attr_list, length))
   stopifnot(all(unique_attr)  <= 1)
 
   # missing labels, if any
   miss_values <- label_df[which(label_df$missings == "miss"), "value"]
-  if(length(miss_values) > 0 && length(miss_values) <= 3)  out[["na_values"]] <- miss_values
-  if(length(miss_values) > 3)  out[["na_range"]] <- range(miss_values)
+  attr_list <- add_miss_tags(varName = varName, attr_list = attr_list, miss_values = miss_values, raw_dat = raw_dat)
 
-  # out[["class"]] <- strsplit(out[["class"]], split = ", ")[[1]]
   # give specific class depending on a) value labels are needed or not and b) missings are given or not:
-  if(identical(labeled, "yes")) out[["class"]] <- c("haven_labelled")
-  if(identical(labeled, "yes") & all(is.na(label_df$value))) out[["class"]] <- c("haven_labelled_spss")
+  if(identical(labeled, "yes")) attr_list[["class"]] <- c("haven_labelled")
+  if(identical(labeled, "yes") & all(is.na(label_df$value))) attr_list[["class"]] <- c("haven_labelled_spss")
   any_miss <- length(miss_values) > 0
-  if(identical(out[["class"]], "haven_labelled") && any_miss) out[["class"]] <- c("haven_labelled_spss", "haven_labelled")
+  if(identical(attr_list[["class"]], "haven_labelled") && any_miss) attr_list[["class"]] <- c("haven_labelled_spss", "haven_labelled")
 
   # experimental class modification (due to haven 2.3.0 classes got modified)
   #stopifnot(varClass %in% c("numeric", "character"))
-  #out[["class"]] <- c(out[["class"]], "vctrs_vctr", ifelse(varClass == "numeric", yes = "double", no = "character"))
+  #attr_list[["class"]] <- c(attr_list[["class"]], "vctrs_vctr", ifelse(varClass == "numeric", yes = "double", no = "character"))
 
   # value labels, if any
   value_label_df <- label_df[!is.na(label_df$value), ]
   if(nrow(value_label_df) > 0) {
-    out[["labels"]] <- value_label_df[, "value"]
-    names(out[["labels"]]) <- value_label_df[, "valLabel"]
+    attr_list[["labels"]] <- value_label_df[, "value"]
+    names(attr_list[["labels"]]) <- value_label_df[, "valLabel"]
   }
 
   # value labels and missing codes need to have the same class as the variable format
-  #if(all(label_df$varName == "groupVar")) browser()
-  if((length(out[["format.spss"]]) > 0 && grepl("^A", unique(out[["format.spss"]]))) || identical(varClass, "character")) {
-    #if((length(out[["format.spss"]]) > 0 && grepl("^A", unique(out[["format.spss"]])))) {
-    out[["na_values"]] <- as.character(out[["na_values"]])
+  if((length(attr_list[["format.spss"]]) > 0 &&
+      grepl("^A", unique(attr_list[["format.spss"]]))) ||
+     identical(varClass, "character")) {
+    attr_list[["na_values"]] <- as.character(attr_list[["na_values"]])
     if(nrow(value_label_df) > 0) {
-      out[["labels"]] <- as.character(out[["labels"]])
-      names(out[["labels"]]) <- value_label_df[, "valLabel"]
+      attr_list[["labels"]] <- as.character(attr_list[["labels"]])
+      names(attr_list[["labels"]]) <- value_label_df[, "valLabel"]
     }
-    #if(identical(labeled, "yes")) out[["class"]] <- c("haven_labelled")
+    #if(identical(labeled, "yes")) attr_list[["class"]] <- c("haven_labelled")
   }
 
-  #if(any(label_df$varName == "TESTUNG")) browser()
-  out
+  attr_list
 }
 
+# missing tag conversion to suit SPSS style (maximum 3 discrete missing tags or range of missing tags)
+add_miss_tags <- function(varName, attr_list, miss_values, raw_dat) {
+  if(length(miss_values) > 0 && length(miss_values) <= 3)  {
+    attr_list[["na_values"]] <- miss_values
+  }
+  if(length(miss_values) > 3) {
+    full_range <- range(miss_values)
+    other_raw_dat <- raw_dat[!raw_dat %in% miss_values]
+    # what about character strings?
+    accidental_miss_tags <- other_raw_dat[!is.na(other_raw_dat) &
+                                            other_raw_dat >= full_range[1] & other_raw_dat <= full_range[2]]
+    if(length(accidental_miss_tags) > 0) {
+      stop("Missing tag conversion for variable '", varName,"' to SPSS conventions is not possible, as the new missing range (", full_range[1], " to ", full_range[2], ") would include the following values not tagged as missing in the data: ",
+              paste(accidental_miss_tags, collapse = ", "),
+           ". Adjust missing tags to export to tibble or write to SPSS.")
+    }
+
+    attr_list[["na_range"]] <- full_range
+  }
+  attr_list
+}

--- a/R/export_tibble.R
+++ b/R/export_tibble.R
@@ -3,10 +3,10 @@
 #############################################################################
 #' Transform a \code{GADSdat} to a \code{tibble}
 #'
-#' \code{haven}'s \code{\link[haven]{read_spss()}} stores data together with meta data (e.g. value and variable labels) in a
+#' \code{haven}'s \code{\link[haven]{read_spss}} stores data together with meta data (e.g. value and variable labels) in a
 #' \code{tibble} with attributes on variable level. This function transforms a \code{GADSdat} object to such a \code{tibble}.
 #'
-#' This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss()}}.
+#' This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss}}.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
 #'

--- a/R/write_spss.R
+++ b/R/write_spss.R
@@ -7,27 +7,27 @@
 #' or \code{Stata} file (\code{dta}).
 #' See 'details' for some important limitations.
 #'
-#' The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav}} and
-#' \code{\link[haven:read_dta]{write_dta}} functions.
+#' The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav()}} and
+#' \code{\link[haven:read_dta]{write_dta()}} functions.
 #'
-#' Currently known limitations for \code{write_spss} are:
+#' Currently known limitations for \code{write_spss()} are:
 #' \itemize{
-#' \item{a) } {value labels for long character variables (> \code{A10}) are dropped}
-#' \item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly displayed as multiple
-#' character variables in \code{SPSS}}
-#' \item{c) } {exporting date or time variables is currently not supported}
+#' \item{a) } {value labels for long character variables (> \code{A10}) are dropped,}
+#' \item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly
+#' displayed as multiple character variables in \code{SPSS},}
+#' \item{c) } {exporting date or time variables is currently not supported,}
 #' \item{d) } {missing tags are slightly incompatible between \code{SPSS} and \code{eatGADS}
 #' as \code{eatGADS} supports unlimited discrete missing tags (but no range of missing tags) and
 #' \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
-#' is assigned more than three discrete missing tags, \code{write_spss} (more precisely \code{\link{export_tibble}})
+#' is assigned more than three discrete missing tags, \code{write_spss()} (more precisely \code{\link{export_tibble()}})
 #' performs a silent conversion of the discrete missing tags into a missing range.
 #' If this conversion affects other value labels or values in the data not tagged as missing, an error is issued.}
 #'}
 #'
-#' Currently known limitations for \code{write_stata} are:
+#' Currently known limitations for \code{write_stata()} are:
 #' \itemize{
-#' \item{a) }{Variable format is dropped}
-#' \item{b) }{missing codes are dropped}
+#' \item{a) }{Variable format is dropped,}
+#' \item{b) }{missing codes are dropped.}
 #' }
 #'
 #'@param GADSdat A \code{GADSdat} object.

--- a/R/write_spss.R
+++ b/R/write_spss.R
@@ -11,12 +11,24 @@
 #' \code{\link[haven:read_dta]{write_dta}} functions.
 #'
 #' Currently known limitations for \code{write_spss} are:
-#' (a) value labels for long character variables (> \code{A10}) are
-#' dropped, (b) under specific conditions very long character variables (> \code{A254}) are incorrectly displayed as multiple
-#' character variables in \code{SPSS}. Furthermore, \code{write_spss} currently does not support exporting date or time variables.
+#' \itemize{
+#' \item{a) } {value labels for long character variables (> \code{A10}) are dropped}
+#' \item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly displayed as multiple
+#' character variables in \code{SPSS}}
+#' \item{c) } {exporting date or time variables is currently not supported}
+#' \item{d) } {missing tags are slightly incompatible between \code{SPSS} and \code{eatGADS}
+#' as \code{eatGADS} supports unlimited discrete missing tags (but no range of missing tags) and
+#' \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
+#' is assigned more than three discrete missing tags, \code{write_spss} (more precisely \code{\link{export_tibble}})
+#' performs a silent conversion of the discrete missing tags into a missing range.
+#' If this conversion affects values not tagged as missing in the data, an error is issued.}
+#'}
 #'
 #' Currently known limitations for \code{write_stata} are:
-#' (a) Variable format is dropped, (b) missing codes are dropped.
+#' \itemize{
+#' \item{a) }{Variable format is dropped}
+#' \item{b) }{missing codes are dropped}
+#' }
 #'
 #'@param GADSdat A \code{GADSdat} object.
 #'@param filePath Path of \code{sav} file to write.

--- a/R/write_spss.R
+++ b/R/write_spss.R
@@ -21,7 +21,7 @@
 #' \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
 #' is assigned more than three discrete missing tags, \code{write_spss} (more precisely \code{\link{export_tibble}})
 #' performs a silent conversion of the discrete missing tags into a missing range.
-#' If this conversion affects values not tagged as missing in the data, an error is issued.}
+#' If this conversion affects other value labels or values in the data not tagged as missing, an error is issued.}
 #'}
 #'
 #' Currently known limitations for \code{write_stata} are:

--- a/R/write_spss.R
+++ b/R/write_spss.R
@@ -7,10 +7,10 @@
 #' or \code{Stata} file (\code{dta}).
 #' See 'details' for some important limitations.
 #'
-#' The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav()}} and
-#' \code{\link[haven:read_dta]{write_dta()}} functions.
+#' The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav}} and
+#' \code{\link[haven:read_dta]{write_dta}} functions.
 #'
-#' Currently known limitations for \code{write_spss()} are:
+#' Currently known limitations for \code{write_spss} are:
 #' \itemize{
 #' \item{a) } {value labels for long character variables (> \code{A10}) are dropped,}
 #' \item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly
@@ -19,12 +19,12 @@
 #' \item{d) } {missing tags are slightly incompatible between \code{SPSS} and \code{eatGADS}
 #' as \code{eatGADS} supports unlimited discrete missing tags (but no range of missing tags) and
 #' \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
-#' is assigned more than three discrete missing tags, \code{write_spss()} (more precisely \code{\link{export_tibble()}})
+#' is assigned more than three discrete missing tags, \code{write_spss()} (more precisely \code{\link{export_tibble}})
 #' performs a silent conversion of the discrete missing tags into a missing range.
 #' If this conversion affects other value labels or values in the data not tagged as missing, an error is issued.}
 #'}
 #'
-#' Currently known limitations for \code{write_stata()} are:
+#' Currently known limitations for \code{write_stata} are:
 #' \itemize{
 #' \item{a) }{Variable format is dropped,}
 #' \item{b) }{missing codes are dropped.}

--- a/man/export_tibble.Rd
+++ b/man/export_tibble.Rd
@@ -17,7 +17,7 @@ Returns a \code{tibble}.
 \code{tibble} with attributes on variable level. This function transforms a \code{GADSdat} object to such a \code{tibble}.
 }
 \details{
-This function is mainly intended for internal use.
+This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss}}.
 }
 \examples{
 pisa_tbl <- export_tibble(pisa)

--- a/man/export_tibble.Rd
+++ b/man/export_tibble.Rd
@@ -13,11 +13,11 @@ export_tibble(GADSdat)
 Returns a \code{tibble}.
 }
 \description{
-\code{haven}'s \code{\link[haven]{read_spss}} stores data together with meta data (e.g. value and variable labels) in a
+\code{haven}'s \code{\link[haven]{read_spss()}} stores data together with meta data (e.g. value and variable labels) in a
 \code{tibble} with attributes on variable level. This function transforms a \code{GADSdat} object to such a \code{tibble}.
 }
 \details{
-This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss}}.
+This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss()}}.
 }
 \examples{
 pisa_tbl <- export_tibble(pisa)

--- a/man/export_tibble.Rd
+++ b/man/export_tibble.Rd
@@ -13,11 +13,11 @@ export_tibble(GADSdat)
 Returns a \code{tibble}.
 }
 \description{
-\code{haven}'s \code{\link[haven]{read_spss()}} stores data together with meta data (e.g. value and variable labels) in a
+\code{haven}'s \code{\link[haven]{read_spss}} stores data together with meta data (e.g. value and variable labels) in a
 \code{tibble} with attributes on variable level. This function transforms a \code{GADSdat} object to such a \code{tibble}.
 }
 \details{
-This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss()}}.
+This function is mainly intended for internal use. For further documentation see also \code{\link{write_spss}}.
 }
 \examples{
 pisa_tbl <- export_tibble(pisa)

--- a/man/write_spss.Rd
+++ b/man/write_spss.Rd
@@ -23,10 +23,10 @@ or \code{Stata} file (\code{dta}).
 See 'details' for some important limitations.
 }
 \details{
-The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav()}} and
-\code{\link[haven:read_dta]{write_dta()}} functions.
+The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav}} and
+\code{\link[haven:read_dta]{write_dta}} functions.
 
-Currently known limitations for \code{write_spss()} are:
+Currently known limitations for \code{write_spss} are:
 \itemize{
 \item{a) } {value labels for long character variables (> \code{A10}) are dropped,}
 \item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly
@@ -35,12 +35,12 @@ displayed as multiple character variables in \code{SPSS},}
 \item{d) } {missing tags are slightly incompatible between \code{SPSS} and \code{eatGADS}
 as \code{eatGADS} supports unlimited discrete missing tags (but no range of missing tags) and
 \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
-is assigned more than three discrete missing tags, \code{write_spss()} (more precisely \code{\link{export_tibble()}})
+is assigned more than three discrete missing tags, \code{write_spss()} (more precisely \code{\link{export_tibble}})
 performs a silent conversion of the discrete missing tags into a missing range.
 If this conversion affects other value labels or values in the data not tagged as missing, an error is issued.}
 }
 
-Currently known limitations for \code{write_stata()} are:
+Currently known limitations for \code{write_stata} are:
 \itemize{
 \item{a) }{Variable format is dropped,}
 \item{b) }{missing codes are dropped.}

--- a/man/write_spss.Rd
+++ b/man/write_spss.Rd
@@ -37,7 +37,7 @@ as \code{eatGADS} supports unlimited discrete missing tags (but no range of miss
 \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
 is assigned more than three discrete missing tags, \code{write_spss} (more precisely \code{\link{export_tibble}})
 performs a silent conversion of the discrete missing tags into a missing range.
-If this conversion affects values not tagged as missing in the data, an error is issued.}
+If this conversion affects other value labels or values in the data not tagged as missing, an error is issued.}
 }
 
 Currently known limitations for \code{write_stata} are:

--- a/man/write_spss.Rd
+++ b/man/write_spss.Rd
@@ -27,12 +27,24 @@ The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{
 \code{\link[haven:read_dta]{write_dta}} functions.
 
 Currently known limitations for \code{write_spss} are:
-(a) value labels for long character variables (> \code{A10}) are
-dropped, (b) under specific conditions very long character variables (> \code{A254}) are incorrectly displayed as multiple
-character variables in \code{SPSS}. Furthermore, \code{write_spss} currently does not support exporting date or time variables.
+\itemize{
+\item{a) } {value labels for long character variables (> \code{A10}) are dropped}
+\item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly displayed as multiple
+character variables in \code{SPSS}}
+\item{c) } {exporting date or time variables is currently not supported}
+\item{d) } {missing tags are slightly incompatible between \code{SPSS} and \code{eatGADS}
+as \code{eatGADS} supports unlimited discrete missing tags (but no range of missing tags) and
+\code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
+is assigned more than three discrete missing tags, \code{write_spss} (more precisely \code{\link{export_tibble}})
+performs a silent conversion of the discrete missing tags into a missing range.
+If this conversion affects values not tagged as missing in the data, an error is issued.}
+}
 
 Currently known limitations for \code{write_stata} are:
-(a) Variable format is dropped, (b) missing codes are dropped.
+\itemize{
+\item{a) }{Variable format is dropped}
+\item{b) }{missing codes are dropped}
+}
 }
 \examples{
 

--- a/man/write_spss.Rd
+++ b/man/write_spss.Rd
@@ -23,27 +23,27 @@ or \code{Stata} file (\code{dta}).
 See 'details' for some important limitations.
 }
 \details{
-The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav}} and
-\code{\link[haven:read_dta]{write_dta}} functions.
+The provided functionality relies on \code{havens} \code{\link[haven:read_spss]{write_sav()}} and
+\code{\link[haven:read_dta]{write_dta()}} functions.
 
-Currently known limitations for \code{write_spss} are:
+Currently known limitations for \code{write_spss()} are:
 \itemize{
-\item{a) } {value labels for long character variables (> \code{A10}) are dropped}
-\item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly displayed as multiple
-character variables in \code{SPSS}}
-\item{c) } {exporting date or time variables is currently not supported}
+\item{a) } {value labels for long character variables (> \code{A10}) are dropped,}
+\item{b) } {under specific conditions very long character variables (> \code{A254}) are incorrectly
+displayed as multiple character variables in \code{SPSS},}
+\item{c) } {exporting date or time variables is currently not supported,}
 \item{d) } {missing tags are slightly incompatible between \code{SPSS} and \code{eatGADS}
 as \code{eatGADS} supports unlimited discrete missing tags (but no range of missing tags) and
 \code{SPSS} only supports up to three discrete missing tags or ranges of missing tags. For this purpose, if a variable
-is assigned more than three discrete missing tags, \code{write_spss} (more precisely \code{\link{export_tibble}})
+is assigned more than three discrete missing tags, \code{write_spss()} (more precisely \code{\link{export_tibble()}})
 performs a silent conversion of the discrete missing tags into a missing range.
 If this conversion affects other value labels or values in the data not tagged as missing, an error is issued.}
 }
 
-Currently known limitations for \code{write_stata} are:
+Currently known limitations for \code{write_stata()} are:
 \itemize{
-\item{a) }{Variable format is dropped}
-\item{b) }{missing codes are dropped}
+\item{a) }{Variable format is dropped,}
+\item{b) }{missing codes are dropped.}
 }
 }
 \examples{

--- a/tests/testthat/test_export_tibble.R
+++ b/tests/testthat/test_export_tibble.R
@@ -31,13 +31,17 @@ test_that("Check for variable type and format.spss", {
 
 ### check single variable label adding
 test_that("Variable labels are added correctly to attributes, for single variable", {
-  expect_equal(addLabels_single(varName = "test", label_df_V2, varClass = "numeric"), expected_V2)
+  expect_equal(addLabels_single(varName = "V2", label_df = label_df_V2, raw_dat = df$dat$V2),
+               expected_V2)
 })
 
 test_that("Variable labels are added correctly to attributes, for single character variable", {
   label_df_V2_string <- label_df_V2
   label_df_V2_string$format <- "A20"
-  expect_equal(class(addLabels_single(varName = "test", label_df_V2_string, "character")$labels), "character")
+  df2  <- df
+  df2$dat$V2 <- as.character(df2$dat$V2)
+  expect_equal(class(addLabels_single(varName = "V2", label_df = label_df_V2_string, raw_dat = df2$dat$V2)$labels),
+               "character")
 })
 
 test_that("Value labels work correctly for character variable with and without SPSS format", {
@@ -78,8 +82,8 @@ expected_Species <- list(class = c("haven_labelled"),
                          labels = c(setosa = 1, versicolor = 2, virginica = 3))
 
 test_that("Variable labels are added correctly for factor", {
-  expect_equal(addLabels_single(varName = "Species", iris2$labels[iris2$labels$varName == "Species", ],
-                                varClass = "numeric"),
+  expect_equal(addLabels_single(varName = "Species", label_df = iris2$labels[iris2$labels$varName == "Species", ],
+                                raw_dat = iris2$dat$Species),
                expected_Species)
 })
 
@@ -99,7 +103,7 @@ test_that("add_miss_tags errors", {
 
   expect_error(add_miss_tags(varName = "VAR1", attr_list = list(),
                                        label_df = miss_labs, raw_dat = miss_dat2),
-               "Missing tag conversion for variable 'VAR1' to SPSS conventions is not possible, as the new missing range (-99 to -80) would include the following values not tagged as missing in the data: -85, -86. Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
+               "Conversion of missing tags for variable 'VAR1' to SPSS conventions is not possible, as the new missing range (-99 to -80) would include the following values not tagged as missing in the data: -85, -86. Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
 
   # conflict in value labels
   dfSAV3 <- changeValLabels(dfSAV2, varName = "VAR1", value = c(-85), valLabel = c("some label"))
@@ -107,7 +111,7 @@ test_that("add_miss_tags errors", {
 
   expect_error(add_miss_tags(varName = "VAR1", attr_list = list(),
                              label_df = miss_labs3, raw_dat = dfSAV$dat$VAR1),
-               "Missing tag conversion for variable 'VAR1' to SPSS conventions is not possible, as the new missing range (-99 to -80) would include the following labeled values not tagged as missing: -85. Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
+               "Conversion of missing tags for variable 'VAR1' to SPSS conventions is not possible, as the new missing range (-99 to -80) would include the following labeled values not tagged as missing: -85. Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
 
   # character variable
   dfSAV4 <- dfSAV2
@@ -117,7 +121,7 @@ test_that("add_miss_tags errors", {
 
   expect_error(add_miss_tags(varName = "VAR1", attr_list = list(),
                              label_df = miss_labs4, raw_dat = dfSAV4$dat$VAR1),
-               "Missing tag conversion for variable 'VAR1' to SPSS conventions is not possible, as too many missings are declared for a character variable (maximum 3). Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
+               "Conversion of missing tags for variable 'VAR1' to SPSS conventions is not possible, as too many missings are declared for a character variable (maximum 3). Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
 
 
 })

--- a/tests/testthat/test_export_tibble.R
+++ b/tests/testthat/test_export_tibble.R
@@ -88,13 +88,13 @@ dfSAV2 <- changeMissings(dfSAV, varName = "VAR1", value = c(-90, -80), missings 
 miss_labs <- dfSAV2$labels[dfSAV2$labels$varName == "VAR1", ]
 
 test_that("add_miss_tags", {
-  out <- add_miss_tags(varName = "VAR1", attr_list = list(), label_df = miss_labs, raw_dat = miss_dat)
+  out <- add_miss_tags(varName = "VAR1", attr_list = list(), label_df = miss_labs, raw_dat = dfSAV$dat$VAR1)
   expect_equal(out, list(na_range = c(-99, -80)))
 })
 
 test_that("add_miss_tags errors", {
   # conflict in data
-  miss_dat2 <- miss_dat <- dfSAV$dat$VAR1
+  miss_dat2 <- dfSAV$dat$VAR1
   miss_dat2[c(1, 4)] <- c(-85, -86)
 
   expect_error(add_miss_tags(varName = "VAR1", attr_list = list(),
@@ -106,7 +106,7 @@ test_that("add_miss_tags errors", {
   miss_labs3 <- dfSAV3$labels[dfSAV3$labels$varName == "VAR1", ]
 
   expect_error(add_miss_tags(varName = "VAR1", attr_list = list(),
-                             label_df = miss_labs3, raw_dat = miss_dat),
+                             label_df = miss_labs3, raw_dat = dfSAV$dat$VAR1),
                "Missing tag conversion for variable 'VAR1' to SPSS conventions is not possible, as the new missing range (-99 to -80) would include the following labeled values not tagged as missing: -85. Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
 
   # character variable
@@ -116,7 +116,7 @@ test_that("add_miss_tags errors", {
   miss_labs4 <- dfSAV2$labels[dfSAV2$labels$varName == "VAR1", ]
 
   expect_error(add_miss_tags(varName = "VAR1", attr_list = list(),
-                             label_df = miss_labs4, raw_dat = miss_dat5),
+                             label_df = miss_labs4, raw_dat = dfSAV4$dat$VAR1),
                "Missing tag conversion for variable 'VAR1' to SPSS conventions is not possible, as too many missings are declared for a character variable (maximum 3). Adjust missing tags to export to tibble or write to SPSS.", fixed = TRUE)
 
 


### PR DESCRIPTION
While `eatGADS` allows unlimited discrete missing tags (e.g., `-99, -98, -97, -96, 90`), `SPSS` only allows up to three discrete missing tags (e.g., `-99, -98, -97`) or a range of missing tags (e.g., `-99` to `90`). To date, a silent conversion was performed by `export_tibble()`.

However, this can be an issue, if the conversion leads to non-missing values in the actual data or value labels being turned into missings (e.g., `1` is a non-missing labeled value). Furthermore, no missing ranges are possible in SPSS for character variables. This issue is mentioned in #45 and adressed in this PR via raising an error in such cases. 

One review is sufficient, feel free to assign yourself if available @everyone.