### PR TITLE
extend reuseMeta to vectorized input; adresses #20

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* `reuseMeta()` now can be use on multiple variables at once
 * `inspectMetaDifferences()` now can be applied to data bases as well
 * `recodeNA2missing()` for recoding `NAs` to a specific missing code
 * `recode2NA()` now allows the recoding of multiple `values` at once and returns a warning, if the recoded values have existing value labels in the recoded variables

--- a/R/reuseMeta.R
+++ b/R/reuseMeta.R
@@ -1,17 +1,17 @@
 #### Reuse Meta
 #############################################################################
-#' Use meta data for a variable from another \code{GADSdat}.
+#' Use meta data for variables from another \code{GADSdat}.
 #'
-#' Transfer meta information from one \code{GADSdat} to another.
+#' Transfer meta information from one \code{GADSdat} to another for one or multiple variables.
 #'
 #' Transfer of meta information can mean substituting the complete meta information, only adding value labels, adding only
 #' \code{"valid"} or adding only \code{"miss"} missing labels.
-#' See the arguments \code{missingLabels} and \code{addValueLabels} for further information.
+#' See the arguments \code{missingLabels} and \code{addValueLabels} for further details.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
-#'@param varName Name of the variable that should get the new meta data.
-#'@param other_GADSdat \code{GADSdat} object imported via \code{eatGADS} including the desired meta information. Can also be a GADS db or an \code{all_GADSdat} object.
-#'@param other_varName Name of the variable that should get the new meta data in the \code{other_GADSdat}.
+#'@param varName Character vector with the names of the variables that should get the new meta data.
+#'@param other_GADSdat \code{GADSdat} object imported via \code{eatGADS} including the desired meta information. Can either be a \code{GADSdat}, an \code{eatGADS} data base or an \code{all_GADSdat} object.
+#'@param other_varName Character vector with the names of the variables in \code{other_GADSdat} that contain the meta data which should be copied.
 #'@param missingLabels How should meta data for missing values be treated? If \code{NULL}, missing values are transferred as all other labels. If \code{"drop"}, missing labels are dropped (useful for imputed data). If \code{"leave"}, missing labels remain untouched. If \code{"only"}, all valid value labels are dropped.
 #'@param addValueLabels Should only value labels be added and all other meta information retained?
 #'
@@ -21,15 +21,38 @@
 #'# see createGADS vignette
 #'
 #'@export
-reuseMeta <- function(GADSdat, varName, other_GADSdat, other_varName = NULL, missingLabels = NULL, addValueLabels = FALSE) {
+reuseMeta <- function(GADSdat, varName, other_GADSdat, other_varName = NULL,
+                      missingLabels = NULL, addValueLabels = FALSE) {
   UseMethod("reuseMeta")
 }
 #'@export
-reuseMeta.GADSdat <- function(GADSdat, varName, other_GADSdat, other_varName = NULL, missingLabels = NULL, addValueLabels = FALSE) {
-  if(!is.null(missingLabels) && !missingLabels %in% c("drop", "leave", "only")) stop("Invalid input for argument missingLabels.")
-  if(!varName %in% names(GADSdat$dat)) stop("varName is not a variable in the GADSdat.")
-  # extract meta data
+reuseMeta.GADSdat <- function(GADSdat, varName, other_GADSdat, other_varName = NULL,
+                              missingLabels = NULL, addValueLabels = FALSE) {
+  check_GADSdat(GADSdat)
+  check_vars_in_GADSdat(GADSdat, vars = varName)
+  if(inherits(other_GADSdat, "GADSdat")) check_GADSdat(other_GADSdat)
+  if(inherits(other_GADSdat, "all_GADSdat")) check_all_GADSdat(other_GADSdat)
   if(is.null(other_varName)) other_varName <- varName
+  check_vars_in_GADSdat(other_GADSdat, vars = other_varName)
+  if(length(varName) != length(other_varName)) {
+    stop("'varName' and 'other_varName' have different length.")
+  }
+
+  if(!is.null(missingLabels) && !missingLabels %in% c("drop", "leave", "only")) {
+    stop("Invalid input for argument missingLabels.")
+  }
+  check_logicalArgument(addValueLabels, argName = "addValueLabels")
+
+  for(i in seq_along(varName)) {
+    GADSdat <- reuseMeta_singleVariable(GADSdat, varName = varName[i],
+                                        other_GADSdat = other_GADSdat, other_varName = other_varName[i],
+                                        missingLabels = missingLabels, addValueLabels = addValueLabels)
+  }
+  GADSdat
+}
+
+reuseMeta_singleVariable <- function(GADSdat, varName, other_GADSdat, other_varName = NULL,
+                                     missingLabels = NULL, addValueLabels = FALSE){
   new_meta <- extractMeta(other_GADSdat, other_varName)
   # compatability with meta data from all_GADSdat or data base (variable can be foreign key and occur multiply)
   if("data_table" %in% names(new_meta)) {

--- a/R/reuseMeta.R
+++ b/R/reuseMeta.R
@@ -39,7 +39,7 @@ reuseMeta.GADSdat <- function(GADSdat, varName, other_GADSdat, other_varName = N
   }
 
   if(!is.null(missingLabels) && !missingLabels %in% c("drop", "leave", "only")) {
-    stop("Invalid input for argument missingLabels.")
+    stop("Invalid input for argument missingLabels. Must be either NULL, 'drop', 'leave', or 'only'.")
   }
   check_logicalArgument(addValueLabels, argName = "addValueLabels")
 

--- a/man/reuseMeta.Rd
+++ b/man/reuseMeta.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/reuseMeta.R
 \name{reuseMeta}
 \alias{reuseMeta}
-\title{Use meta data for a variable from another \code{GADSdat}.}
+\title{Use meta data for variables from another \code{GADSdat}.}
 \usage{
 reuseMeta(
   GADSdat,
@@ -16,11 +16,11 @@ reuseMeta(
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
-\item{varName}{Name of the variable that should get the new meta data.}
+\item{varName}{Character vector with the names of the variables that should get the new meta data.}
 
-\item{other_GADSdat}{\code{GADSdat} object imported via \code{eatGADS} including the desired meta information. Can also be a GADS db or an \code{all_GADSdat} object.}
+\item{other_GADSdat}{\code{GADSdat} object imported via \code{eatGADS} including the desired meta information. Can either be a \code{GADSdat}, an \code{eatGADS} data base or an \code{all_GADSdat} object.}
 
-\item{other_varName}{Name of the variable that should get the new meta data in the \code{other_GADSdat}.}
+\item{other_varName}{Character vector with the names of the variables in \code{other_GADSdat} that contain the meta data which should be copied.}
 
 \item{missingLabels}{How should meta data for missing values be treated? If \code{NULL}, missing values are transferred as all other labels. If \code{"drop"}, missing labels are dropped (useful for imputed data). If \code{"leave"}, missing labels remain untouched. If \code{"only"}, all valid value labels are dropped.}
 
@@ -30,12 +30,12 @@ reuseMeta(
 Returns the original object with updated meta data.
 }
 \description{
-Transfer meta information from one \code{GADSdat} to another.
+Transfer meta information from one \code{GADSdat} to another for one or multiple variables.
 }
 \details{
 Transfer of meta information can mean substituting the complete meta information, only adding value labels, adding only
 \code{"valid"} or adding only \code{"miss"} missing labels.
-See the arguments \code{missingLabels} and \code{addValueLabels} for further information.
+See the arguments \code{missingLabels} and \code{addValueLabels} for further details.
 }
 \examples{
 # see createGADS vignette

--- a/tests/testthat/test_reuseMeta.R
+++ b/tests/testthat/test_reuseMeta.R
@@ -10,7 +10,7 @@ test_that("Input validation", {
                "'varName' and 'other_varName' have different length.")
   expect_error(reuseMeta(dfSAV, varName = "VAR1", other_GADSdat = dfSAV, other_varName = "VAR1",
                          missingLabels = "test"),
-               "Invalid input for argument missingLabels.")
+               "Invalid input for argument missingLabels. Must be either NULL, 'drop', 'leave', or 'only'.")
 })
 
 test_that("Drop missing labels from meta", {

--- a/tests/testthat/test_reuseMeta.R
+++ b/tests/testthat/test_reuseMeta.R
@@ -5,6 +5,14 @@ load(file = "helper_data.rda")
 dfSAV <- import_spss(file = "helper_spss_missings.sav")
 
 
+test_that("Input validation", {
+  expect_error(reuseMeta(dfSAV, varName = "VAR1", other_GADSdat = dfSAV, other_varName = c("VAR1", "VAR2")),
+               "'varName' and 'other_varName' have different length.")
+  expect_error(reuseMeta(dfSAV, varName = "VAR1", other_GADSdat = dfSAV, other_varName = "VAR1",
+                         missingLabels = "test"),
+               "Invalid input for argument missingLabels.")
+})
+
 test_that("Drop missing labels from meta", {
   # if no changes
   expect_equal(drop_missing_labels(df1$labels[df1$labels$varName == "ID1", ]), df1$labels[df1$labels$varName == "ID1", ])
@@ -81,4 +89,14 @@ test_that("Reuse meta adding value labels to an unlabeled variable", {
 test_that("Bugfix if only missing rows and missingLabels = leave", {
   out <- reuseMeta(dfSAV, varName = "VAR3", other_GADSdat = dfSAV, other_varName = "VAR1", missingLabels = "leave")
   expect_equal(nrow(out$labels), 8)
+})
+
+test_that("Transfer meta information for multiple variables", {
+  dat2 <- import_DF(dfSAV$dat)
+  dat3 <- reuseMeta(dat2, varName = c("VAR1", "VAR2", "VAR3"), dfSAV)
+  expect_equal(dfSAV, dat3)
+  dat4 <- changeVarNames(dat2, oldNames = "VAR1", newNames = "v1")
+  dat5 <- reuseMeta(dat4, varName = c("v1", "VAR2", "VAR3"), dfSAV, other_varName = c("VAR1", "VAR2", "VAR3"))
+  dat5 <- changeVarNames(dat5, oldNames = "v1", newNames = "VAR1")
+  expect_equal(dfSAV, dat5)
 })


### PR DESCRIPTION
Extends `reuseMeta()` to work with input vectors (multiple variables instead of just one).