### PR TITLE
Consistent variable name validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* `updateMeta()` no longer internally calls `checkVarNames()`
+* `changeVarNames()` and `applyChangeMeta()` now have checks of new variables names optional via the `checkVarNames` argument
 * `reuseMeta()` now can be use on multiple variables at once
 * `inspectMetaDifferences()` now can be applied to data bases as well
 * `recodeNA2missing()` for recoding `NAs` to a specific missing code
@@ -15,6 +17,7 @@
 ## bug fixes
 * `export_tibble()` and `write_spss()` now throw an error if a conversion of four or more discrete missing tags into a missing range has undesired side effects
 * bug fix in `checkMissingsByValues()`, now correctly reports missing tags outside of the specified value range
+* bug fix in `cloneVariable()`, now is able to assign all possible variables names (fixed conflicts caused by `checkVarName()`)
 
 
 # eatGADS 1.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
-* `updateMeta()` no longer internally calls `checkVarNames()`
-* `changeVarNames()` and `applyChangeMeta()` now have checks of new variables names optional via the `checkVarNames` argument
+* `updateMeta()`, `applyChangeMeta()`, `changeVarNames()`, `cloneVariable()`, `createVariable()`, `composeVar()`, and `dummies2char()` now have optional checks of new variables names via the `checkVarNames` argument
 * `reuseMeta()` now can be use on multiple variables at once
 * `inspectMetaDifferences()` now can be applied to data bases as well
 * `recodeNA2missing()` for recoding `NAs` to a specific missing code

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 ## bug fixes
 * `export_tibble()` and `write_spss()` now throw an error if a conversion of four or more discrete missing tags into a missing range has undesired side effects
 * bug fix in `checkMissingsByValues()`, now correctly reports missing tags outside of the specified value range
-* bug fix in `cloneVariable()`, now is able to assign all possible variables names (fixed conflicts caused by `checkVarName()`)
+* bug fix in `cloneVariable()`, now new variables names which are also `SQLite` keywords no longer throw a error (fixed conflicts caused by `checkVarName()`)
 
 
 # eatGADS 1.0.0

--- a/R/applyChangeMeta.R
+++ b/R/applyChangeMeta.R
@@ -42,6 +42,7 @@ applyChangeMeta.varChanges <- function(changeTable, GADSdat, checkVarNames = TRU
   changeTable <- check_varChanges(changeTable, checkVarNames = checkVarNames)
   check_changeTable(GADSdat, changeTable)
   check_format_vector(changeTable$format_new)
+  check_logicalArgument(checkVarNames, argName = checkVarNames)
 
   dat <- GADSdat$dat
   labels <- GADSdat$labels

--- a/R/applyChangeMeta.R
+++ b/R/applyChangeMeta.R
@@ -16,9 +16,9 @@
 #' \code{existingMeta = "drop"}, which drops all related meta data on value level, or
 #' \code{existingMeta = "ignore"}, which leaves all related meta data on value level untouched.
 #'
-#'
 #'@param changeTable Change table as provided by \code{\link{getChangeMeta}}.
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
+#'@param checkVarNames Logical. Should new variable names be checked by \code{\link{checkVarNames}}?
 #'@param existingMeta If values are recoded, which meta data should be used (see details)?
 #'@param ... further arguments passed to or from other methods.
 #'
@@ -37,9 +37,9 @@ applyChangeMeta <- function(changeTable, GADSdat, ...) {
 
 #'@rdname applyChangeMeta
 #'@export
-applyChangeMeta.varChanges <- function(changeTable, GADSdat, ...) {
+applyChangeMeta.varChanges <- function(changeTable, GADSdat, checkVarNames = TRUE, ...) {
   check_GADSdat(GADSdat)
-  changeTable <- check_varChanges(changeTable)
+  changeTable <- check_varChanges(changeTable, checkVarNames = checkVarNames)
   check_changeTable(GADSdat, changeTable)
   check_format_vector(changeTable$format_new)
 

--- a/R/changeVarNames.R
+++ b/R/changeVarNames.R
@@ -27,6 +27,8 @@ changeVarNames <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
 #### Note: changeVarNames.all_GADSdat could be blueprint for other changes on all_GADSdat level!
 #'@export
 changeVarNames.all_GADSdat <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
+  check_all_GADSdat(GADSdat)
+
   changeDF <- data.frame(oldNames = oldNames, newNames = newNames, stringsAsFactors = FALSE)
   out <- list()
   for(i in names(GADSdat[["datList"]])) {
@@ -39,6 +41,9 @@ changeVarNames.all_GADSdat <- function(GADSdat, oldNames, newNames, checkVarName
 }
 #'@export
 changeVarNames.GADSdat <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
+  check_GADSdat(GADSdat)
+  check_logicalArgument(checkVarNames, argName = checkVarNames)
+
   checkNamesVectors(oldNames = oldNames, newNames = newNames, dat = GADSdat[["dat"]])
   changeTable <- getChangeMeta(GADSdat, level = "variable")
   for(i in seq_along(oldNames)) {

--- a/R/changeVarNames.R
+++ b/R/changeVarNames.R
@@ -11,6 +11,7 @@
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
 #'@param oldNames Vector containing the old variable names.
 #'@param newNames Vector containing the new variable names, in identical order as \code{oldNames}.
+#'@param checkVarNames Logical. Should new variable names be checked by \code{\link{checkVarNames}}?
 #'
 #'@return Returns the \code{GADSdat} object with changed variable names.
 #'
@@ -20,29 +21,30 @@
 #'                         newNames = c("IDstud", "IDschool"))
 #'
 #'@export
-changeVarNames <- function(GADSdat, oldNames, newNames) {
+changeVarNames <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
   UseMethod("changeVarNames")
 }
 #### Note: changeVarNames.all_GADSdat could be blueprint for other changes on all_GADSdat level!
 #'@export
-changeVarNames.all_GADSdat <- function(GADSdat, oldNames, newNames) {
+changeVarNames.all_GADSdat <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
   changeDF <- data.frame(oldNames = oldNames, newNames = newNames, stringsAsFactors = FALSE)
   out <- list()
   for(i in names(GADSdat[["datList"]])) {
     GADSdat_single <- extractGADSdat(GADSdat, name = i)
     changeDF_single <- changeDF[changeDF$oldNames %in% names(GADSdat[["datList"]][[i]]), ]
-    out[[i]] <- changeVarNames(GADSdat = GADSdat_single, oldNames = changeDF_single[["oldNames"]], newNames = changeDF_single[["newNames"]])
+    out[[i]] <- changeVarNames(GADSdat = GADSdat_single, oldNames = changeDF_single[["oldNames"]],
+                               newNames = changeDF_single[["newNames"]], checkVarNames = checkVarNames)
   }
   do.call(mergeLabels, out)
 }
 #'@export
-changeVarNames.GADSdat <- function(GADSdat, oldNames, newNames) {
+changeVarNames.GADSdat <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
   checkNamesVectors(oldNames = oldNames, newNames = newNames, dat = GADSdat[["dat"]])
   changeTable <- getChangeMeta(GADSdat, level = "variable")
   for(i in seq_along(oldNames)) {
     changeTable[changeTable$varName == oldNames[i], "varName_new"] <- newNames[i]
   }
-  applyChangeMeta(GADSdat, changeTable = changeTable)
+  applyChangeMeta(GADSdat, changeTable = changeTable, checkVarNames = checkVarNames)
 }
 
 

--- a/R/cloneVariable.R
+++ b/R/cloneVariable.R
@@ -26,6 +26,7 @@ cloneVariable <- function(GADSdat, varName, new_varName, label_suffix = "", chec
 cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = "", checkVarName = TRUE) {
   check_GADSdat(GADSdat)
   check_vars_in_GADSdat(GADSdat, vars = varName)
+  check_logicalArgument(checkVarName, argName = checkVarName)
   if(new_varName %in% namesGADS(GADSdat)) {
     stop("'",  new_varName, "' is already an existing variable in the 'GADSdat'.")
   }

--- a/R/cloneVariable.R
+++ b/R/cloneVariable.R
@@ -10,6 +10,7 @@
 #'@param varName Name of the variable to be cloned.
 #'@param new_varName Name of the new variable.
 #'@param label_suffix Suffix added to variable label for the newly created variable in the \code{GADSdat}.
+#'@param checkVarName Logical. Should \code{new_varName} be checked by \code{\link{checkVarNames}}?
 #'
 #'@return Returns a \code{GADSdat}.
 #'
@@ -18,11 +19,11 @@
 #' pisa_new <- cloneVariable(pisa, varName = "schtype", new_varName = "schtype_new")
 #'
 #'@export
-cloneVariable <- function(GADSdat, varName, new_varName, label_suffix = "") {
+cloneVariable <- function(GADSdat, varName, new_varName, label_suffix = "", checkVarName = TRUE) {
   UseMethod("cloneVariable")
 }
 #'@export
-cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = "") {
+cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = "", checkVarName = TRUE) {
   check_GADSdat(GADSdat)
   check_vars_in_GADSdat(GADSdat, vars = varName)
   if(new_varName %in% namesGADS(GADSdat)) {
@@ -32,7 +33,10 @@ cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = 
   dat_only <- GADSdat$dat
   dat_only[[new_varName]] <- dat_only[[varName]]
 
-  suppressMessages(GADSdat2 <- updateMeta(GADSdat, newDat = dat_only))
+  suppressMessages(GADSdat2 <- updateMeta(GADSdat, newDat = dat_only, checkVarNames = checkVarName))
+  if(checkVarName) {
+    new_varName <- checkVarNames(new_varName)
+  }
   GADSdat3 <- reuseMeta(GADSdat2, varName = new_varName, other_GADSdat = GADSdat, other_varName = varName)
   GADSdat4 <- append_varLabel(GADSdat3, varName = new_varName, label_suffix = label_suffix)
 

--- a/R/composeVar.R
+++ b/R/composeVar.R
@@ -14,6 +14,7 @@
 #'@param sourceVars Character vector of length two containing the variable names which represent the sources of information.
 #'@param primarySourceVar Character vector containing a single variable name. Which of the \code{sourceVars} should be preferred?
 #'@param newVar Character vector containing the name of the new composite variable.
+#'@param checkVarName Logical. Should \code{newVar} be checked by \code{\link{checkVarNames}}?
 #'
 #'@return The modified \code{GADSdat}.
 #'
@@ -33,17 +34,29 @@
 #'
 #'
 #'@export
-composeVar <- function(GADSdat, sourceVars, primarySourceVar, newVar) {
+composeVar <- function(GADSdat, sourceVars, primarySourceVar, newVar, checkVarName = TRUE) {
   UseMethod("composeVar")
 }
 #'@export
-composeVar.GADSdat <- function(GADSdat, sourceVars, primarySourceVar, newVar) {
+composeVar.GADSdat <- function(GADSdat, sourceVars, primarySourceVar, newVar, checkVarName = TRUE) {
   check_GADSdat(GADSdat)
   check_vars_in_GADSdat(GADSdat, vars = sourceVars)
-  if(!is.character(sourceVars) || length(sourceVars) != 2) stop("'sourceVars' must be a character vector of length 2.")
-  if(!is.character(primarySourceVar) || length(primarySourceVar) != 1) stop("'primarySourceVar' must be a character vector of length 1.")
-  if(!is.character(primarySourceVar) || length(newVar) != 1) stop("'newVar' must be a character vector of length 1.")
-  if(!primarySourceVar %in% sourceVars) stop("'primarySourceVar' must be a name in 'sourceVars'.")
+  check_logicalArgument(checkVarName, argName = "checkVarName")
+  if(!is.character(sourceVars) || length(sourceVars) != 2) {
+    stop("'sourceVars' must be a character vector of length 2.")
+  }
+  if(!is.character(primarySourceVar) || length(primarySourceVar) != 1) {
+    stop("'primarySourceVar' must be a character vector of length 1.")
+  }
+  if(!is.character(primarySourceVar) || length(newVar) != 1) {
+    stop("'newVar' must be a character vector of length 1.")
+  }
+  if(!primarySourceVar %in% sourceVars) {
+    stop("'primarySourceVar' must be a name in 'sourceVars'.")
+  }
+  if(checkVarName) {
+    newVar <- checkVarNames(newVar)
+  }
 
   otherSourceVar <- sourceVars[sourceVars != primarySourceVar]
   suppressWarnings(extracted_dat <- extractData(GADSdat))
@@ -62,8 +75,9 @@ composeVar.GADSdat <- function(GADSdat, sourceVars, primarySourceVar, newVar) {
   ## put into GADS, add meta
   dat_out <- data.frame(GADSdat$dat, comp_var, stringsAsFactors = FALSE)
   names(dat_out)[ncol(dat_out)] <- newVar
-  GADSdat_out <- updateMeta(GADSdat, newDat = dat_out)
-  GADSdat_out2 <- reuseMeta(GADSdat_out, varName = newVar, other_GADSdat = GADSdat_out, other_varName = primarySourceVar, addValueLabels = TRUE)
+  suppressMessages(GADSdat_out <- updateMeta(GADSdat, newDat = dat_out, checkVarNames = FALSE))
+  GADSdat_out2 <- reuseMeta(GADSdat_out, varName = newVar,
+                            other_GADSdat = GADSdat_out, other_varName = primarySourceVar, addValueLabels = TRUE)
 
   # sort
   index_primarySource <- which(namesGADS(GADSdat) == primarySourceVar)

--- a/R/composeVar.R
+++ b/R/composeVar.R
@@ -45,12 +45,8 @@ composeVar.GADSdat <- function(GADSdat, sourceVars, primarySourceVar, newVar, ch
   if(!is.character(sourceVars) || length(sourceVars) != 2) {
     stop("'sourceVars' must be a character vector of length 2.")
   }
-  if(!is.character(primarySourceVar) || length(primarySourceVar) != 1) {
-    stop("'primarySourceVar' must be a character vector of length 1.")
-  }
-  if(!is.character(primarySourceVar) || length(newVar) != 1) {
-    stop("'newVar' must be a character vector of length 1.")
-  }
+  check_characterArgument(primarySourceVar)
+  check_characterArgument(newVar)
   if(!primarySourceVar %in% sourceVars) {
     stop("'primarySourceVar' must be a name in 'sourceVars'.")
   }

--- a/R/createVariable.R
+++ b/R/createVariable.R
@@ -6,6 +6,7 @@
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
 #'@param varName Name of the variable to be cloned.
+#'@param checkVarName Logical. Should \code{varName} be checked by \code{\link{checkVarNames}}?
 #'
 #'@return Returns a \code{GADSdat}.
 #'
@@ -14,17 +15,24 @@
 #' pisa_new <- createVariable(pisa, varName = "new_variable")
 #'
 #'@export
-createVariable <- function(GADSdat, varName) {
+createVariable <- function(GADSdat, varName, checkVarName = TRUE) {
   UseMethod("createVariable")
 }
 #'@export
-createVariable.GADSdat <- function(GADSdat, varName) {
+createVariable.GADSdat <- function(GADSdat, varName, checkVarName = TRUE) {
   check_GADSdat(GADSdat)
-  if(varName %in% namesGADS(GADSdat)) stop("'",  varName, "' is already an existing variable in the 'GADSdat'.")
+  check_logicalArgument(checkVarName, argName = checkVarName)
+  if(varName %in% namesGADS(GADSdat)) {
+    stop("'",  varName, "' is already an existing variable in the 'GADSdat'.")
+  }
+  if(checkVarName){
+    varName <- checkVarNames(varName)
+  }
 
   dat_only <- GADSdat$dat
   dat_only[[varName]] <- NA
 
-  suppressMessages(GADSdat2 <- updateMeta(GADSdat, newDat = dat_only))
+  # perform checkVarNames in this function, as updateMeta provides more messages than desired
+  suppressMessages(GADSdat2 <- updateMeta(GADSdat, newDat = dat_only, checkVarName = FALSE))
   GADSdat2
 }

--- a/R/dummies2char.R
+++ b/R/dummies2char.R
@@ -13,6 +13,7 @@
 #'@param dummies A character vector with the names of the dummy variables.
 #'@param dummyValues A vector with the values which the dummy variables represent.
 #'@param charNames A character vector containing the new variable names.
+#'@param checkVarNames Logical. Should \code{charNames} be checked by \code{\link{checkVarNames}}?
 #'
 #'@return Returns a \code{GADSdat}.
 #'
@@ -31,17 +32,21 @@
 #'
 #'
 #'@export
-dummies2char <- function(GADSdat, dummies, dummyValues, charNames) {
+dummies2char <- function(GADSdat, dummies, dummyValues, charNames, checkVarNames = TRUE) {
   UseMethod("dummies2char")
 }
 
 #'@export
-dummies2char.GADSdat <- function(GADSdat, dummies, dummyValues, charNames) {
+dummies2char.GADSdat <- function(GADSdat, dummies, dummyValues, charNames, checkVarNames = TRUE) {
   check_GADSdat(GADSdat)
+  check_logicalArgument(checkVarNames, argName = "checkVarNames")
   if(!is.character(dummies)) stop("'dummies' needs to be a character vector.")
   if(length(dummies) != length(dummyValues)) stop("'dummyValues' needs to be the same length as 'dummies'.")
   if(length(dummies) != length(charNames)) stop("'charNames' needs to be the same length as 'dummies'.")
   check_vars_in_GADSdat(GADSdat, dummies)
+  if(checkVarNames) {
+    charNames <- checkVarNames(charNames)
+  }
 
   names(dummyValues) <- names(charNames) <- dummies
   for(dummy in dummies) {
@@ -54,7 +59,7 @@ dummies2char.GADSdat <- function(GADSdat, dummies, dummyValues, charNames) {
 
     dat <- GADSdat$dat
     dat[, charName] <- ifelse(dat[, dummy] == 1, yes = dummyValue, no = NA)
-    suppressMessages(GADSdat <- updateMeta(GADSdat, dat))
+    suppressMessages(GADSdat <- updateMeta(GADSdat, dat, checkVarNames = FALSE))
     GADSdat <- reuseMeta(GADSdat, charName, other_GADSdat = GADSdat, other_varName = dummy,
                          missingLabels =  "only", addValueLabels = TRUE)
   }

--- a/R/getChangeMeta.R
+++ b/R/getChangeMeta.R
@@ -63,15 +63,17 @@ new_varChanges <- function(df) {
   stopifnot(is.data.frame(df))
   structure(df, class = c("varChanges", "data.frame"))
 }
-check_varChanges <- function(changeTable) {
+check_varChanges <- function(changeTable, checkVarNames) {
   if(!is.data.frame(changeTable)) stop("changeTable is not a data.frame.")
   colNames <- c("varName", "varLabel", "format", "display_width")
   colNames <- c(colNames, paste0(colNames, "_new"))
   if(any(!names(changeTable) %in% colNames)) stop("Irregular column names in changeTable.")
   # tbd: content checks for format and display width
   # SQLite compliance
-  not_na <- !is.na(changeTable$varName_new)
-  changeTable$varName_new[not_na] <- checkVarNames(as.character(changeTable$varName_new[not_na]))
+  if(checkVarNames) {
+    not_na <- !is.na(changeTable$varName_new)
+    changeTable$varName_new[not_na] <- checkVarNames(as.character(changeTable$varName_new[not_na]))
+  }
   changeTable
 }
 

--- a/R/updateMeta.R
+++ b/R/updateMeta.R
@@ -12,6 +12,7 @@
 #'@param GADSdat \code{GADSdat} or \code{all_GADSdat} object.
 #'@param newDat \code{data.frame} or list of \code{data.frames} with the modified data. \code{tibbles} and \code{data.tables}
 #'are currently not supported and need to be transformed to \code{data.frames} beforehand.
+#'@param checkVarNames Logical. Should new variable names be checked by \code{\link{checkVarNames}}?
 #'
 #'@return Returns the original object with updated meta data (and removes factors from the data).
 #'
@@ -19,17 +20,22 @@
 #' # see createGADS vignette
 #'
 #'@export
-updateMeta <- function(GADSdat, newDat) {
+updateMeta <- function(GADSdat, newDat, checkVarNames = TRUE) {
   UseMethod("updateMeta")
 }
 #'@export
-updateMeta.GADSdat <- function(GADSdat, newDat) {
+updateMeta.GADSdat <- function(GADSdat, newDat, checkVarNames = TRUE) {
   check_GADSdat(GADSdat)
   if(!identical(class(newDat), "data.frame")) stop("newDat needs to be a data.frame. Use as.data.frame is necessary.")
   labels <- GADSdat[["labels"]]
   labels <- remove_rows_meta(labels = labels, allNames = names(newDat))
 
-  addData <- add_rows_meta(labels = labels, newDat = newDat)
+  ## transform variable names in newDat; is done automatically for labels via import_DF
+  if(checkVarNames){
+    newDat <- checkVarNames(newDat)
+  }
+
+  addData <- add_rows_meta(labels = labels, newDat = newDat, checkVarNames = checkVarNames)
   addLabels <- addData[["labels"]]
   labels <- rbind(labels, addLabels) # Reihenfolge der Variablen, ist das wichtig?
   ## replace variables that have been imported newly
@@ -43,7 +49,7 @@ updateMeta.GADSdat <- function(GADSdat, newDat) {
   mod_GADSdat
 }
 #'@export
-updateMeta.all_GADSdat <- function(GADSdat, newDat) {
+updateMeta.all_GADSdat <- function(GADSdat, newDat, checkVarNames = TRUE) {
   check_all_GADSdat(GADSdat)
   stopifnot(is.list(newDat) && all(sapply(newDat, is.data.frame)))
   labels <- GADSdat[["allLabels"]]
@@ -51,7 +57,7 @@ updateMeta.all_GADSdat <- function(GADSdat, newDat) {
   mod_single_GADSdats <- lapply(names(GADSdat[["datList"]]), function(i) {
     message("Analyzing data table ", i, ":")
     single_GADSdat <- new_GADSdat(dat = GADSdat[["datList"]][[i]], labels = labels[labels[, "data_table"] == i, names(labels) != "data_table"])
-    updateMeta(single_GADSdat, newDat = newDat[[i]])
+    updateMeta(single_GADSdat, newDat = newDat[[i]], checkVarNames = checkVarNames)
   })
   names(mod_single_GADSdats) <- names(newDat)
   mod_all_GADSdat <- do.call(mergeLabels, mod_single_GADSdats)
@@ -72,7 +78,7 @@ remove_rows_meta <- function(labels, allNames) {
 }
 
 ### 2) add necessary rows
-add_rows_meta <- function(labels, newDat) {
+add_rows_meta <- function(labels, newDat, checkVarNames) {
   new_vars <- unique(names(newDat)[!names(newDat) %in% labels[, "varName"]])
   if(!length(new_vars) > 0) {
     message("No rows added to meta data.")
@@ -80,7 +86,6 @@ add_rows_meta <- function(labels, newDat) {
   }
   message("Adding meta data for the following variables: ", paste(new_vars, collapse = ", "))
   addDat <- newDat[, new_vars, drop = FALSE]
-  # do not check variable names!
-  suppressMessages(import_DF(addDat, checkVarNames = FALSE))
+  suppressMessages(import_DF(addDat, checkVarNames = checkVarNames))
 }
 

--- a/R/updateMeta.R
+++ b/R/updateMeta.R
@@ -29,9 +29,6 @@ updateMeta.GADSdat <- function(GADSdat, newDat) {
   labels <- GADSdat[["labels"]]
   labels <- remove_rows_meta(labels = labels, allNames = names(newDat))
 
-  ## transform variable names in newDat; is done automatically for labels via import_DF
-  newDat <- checkVarNames(newDat)
-
   addData <- add_rows_meta(labels = labels, newDat = newDat)
   addLabels <- addData[["labels"]]
   labels <- rbind(labels, addLabels) # Reihenfolge der Variablen, ist das wichtig?
@@ -83,6 +80,7 @@ add_rows_meta <- function(labels, newDat) {
   }
   message("Adding meta data for the following variables: ", paste(new_vars, collapse = ", "))
   addDat <- newDat[, new_vars, drop = FALSE]
-  suppressMessages(import_DF(addDat))
+  # do not check variable names!
+  suppressMessages(import_DF(addDat, checkVarNames = FALSE))
 }
 

--- a/R/updateMeta.R
+++ b/R/updateMeta.R
@@ -26,6 +26,7 @@ updateMeta <- function(GADSdat, newDat, checkVarNames = TRUE) {
 #'@export
 updateMeta.GADSdat <- function(GADSdat, newDat, checkVarNames = TRUE) {
   check_GADSdat(GADSdat)
+  check_logicalArgument(checkVarNames, argName = checkVarNames)
   if(!identical(class(newDat), "data.frame")) stop("newDat needs to be a data.frame. Use as.data.frame is necessary.")
   labels <- GADSdat[["labels"]]
   labels <- remove_rows_meta(labels = labels, allNames = names(newDat))

--- a/man/applyChangeMeta.Rd
+++ b/man/applyChangeMeta.Rd
@@ -8,7 +8,7 @@
 \usage{
 applyChangeMeta(changeTable, GADSdat, ...)
 
-\method{applyChangeMeta}{varChanges}(changeTable, GADSdat, ...)
+\method{applyChangeMeta}{varChanges}(changeTable, GADSdat, checkVarNames = TRUE, ...)
 
 \method{applyChangeMeta}{valChanges}(
   changeTable,
@@ -23,6 +23,8 @@ applyChangeMeta(changeTable, GADSdat, ...)
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
 \item{...}{further arguments passed to or from other methods.}
+
+\item{checkVarNames}{Logical. Should new variable names be checked by \code{\link{checkVarNames}}?}
 
 \item{existingMeta}{If values are recoded, which meta data should be used (see details)?}
 }

--- a/man/changeVarNames.Rd
+++ b/man/changeVarNames.Rd
@@ -4,7 +4,7 @@
 \alias{changeVarNames}
 \title{Change Variable Names.}
 \usage{
-changeVarNames(GADSdat, oldNames, newNames)
+changeVarNames(GADSdat, oldNames, newNames, checkVarNames = TRUE)
 }
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
@@ -12,6 +12,8 @@ changeVarNames(GADSdat, oldNames, newNames)
 \item{oldNames}{Vector containing the old variable names.}
 
 \item{newNames}{Vector containing the new variable names, in identical order as \code{oldNames}.}
+
+\item{checkVarNames}{Logical. Should new variable names be checked by \code{\link{checkVarNames}}?}
 }
 \value{
 Returns the \code{GADSdat} object with changed variable names.

--- a/man/cloneVariable.Rd
+++ b/man/cloneVariable.Rd
@@ -4,7 +4,13 @@
 \alias{cloneVariable}
 \title{Clone a variable.}
 \usage{
-cloneVariable(GADSdat, varName, new_varName, label_suffix = "")
+cloneVariable(
+  GADSdat,
+  varName,
+  new_varName,
+  label_suffix = "",
+  checkVarName = TRUE
+)
 }
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
@@ -14,6 +20,8 @@ cloneVariable(GADSdat, varName, new_varName, label_suffix = "")
 \item{new_varName}{Name of the new variable.}
 
 \item{label_suffix}{Suffix added to variable label for the newly created variable in the \code{GADSdat}.}
+
+\item{checkVarName}{Logical. Should \code{new_varName} be checked by \code{\link{checkVarNames}}?}
 }
 \value{
 Returns a \code{GADSdat}.

--- a/man/composeVar.Rd
+++ b/man/composeVar.Rd
@@ -4,7 +4,7 @@
 \alias{composeVar}
 \title{Create a composite variable.}
 \usage{
-composeVar(GADSdat, sourceVars, primarySourceVar, newVar)
+composeVar(GADSdat, sourceVars, primarySourceVar, newVar, checkVarName = TRUE)
 }
 \arguments{
 \item{GADSdat}{\code{GADSdat} or \code{all_GADSdat} object imported via eatGADS.}
@@ -14,6 +14,8 @@ composeVar(GADSdat, sourceVars, primarySourceVar, newVar)
 \item{primarySourceVar}{Character vector containing a single variable name. Which of the \code{sourceVars} should be preferred?}
 
 \item{newVar}{Character vector containing the name of the new composite variable.}
+
+\item{checkVarName}{Logical. Should \code{newVar} be checked by \code{\link{checkVarNames}}?}
 }
 \value{
 The modified \code{GADSdat}.

--- a/man/createVariable.Rd
+++ b/man/createVariable.Rd
@@ -4,12 +4,14 @@
 \alias{createVariable}
 \title{Create a variable.}
 \usage{
-createVariable(GADSdat, varName)
+createVariable(GADSdat, varName, checkVarName = TRUE)
 }
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
 \item{varName}{Name of the variable to be cloned.}
+
+\item{checkVarName}{Logical. Should \code{varName} be checked by \code{\link{checkVarNames}}?}
 }
 \value{
 Returns a \code{GADSdat}.

--- a/man/dummies2char.Rd
+++ b/man/dummies2char.Rd
@@ -4,7 +4,7 @@
 \alias{dummies2char}
 \title{Transform dummy variables to character variables.}
 \usage{
-dummies2char(GADSdat, dummies, dummyValues, charNames)
+dummies2char(GADSdat, dummies, dummyValues, charNames, checkVarNames = TRUE)
 }
 \arguments{
 \item{GADSdat}{A \code{GADSdat} object.}
@@ -14,6 +14,8 @@ dummies2char(GADSdat, dummies, dummyValues, charNames)
 \item{dummyValues}{A vector with the values which the dummy variables represent.}
 
 \item{charNames}{A character vector containing the new variable names.}
+
+\item{checkVarNames}{Logical. Should \code{charNames} be checked by \code{\link{checkVarNames}}?}
 }
 \value{
 Returns a \code{GADSdat}.

--- a/man/updateMeta.Rd
+++ b/man/updateMeta.Rd
@@ -4,13 +4,15 @@
 \alias{updateMeta}
 \title{Update meta data.}
 \usage{
-updateMeta(GADSdat, newDat)
+updateMeta(GADSdat, newDat, checkVarNames = TRUE)
 }
 \arguments{
 \item{GADSdat}{\code{GADSdat} or \code{all_GADSdat} object.}
 
 \item{newDat}{\code{data.frame} or list of \code{data.frames} with the modified data. \code{tibbles} and \code{data.tables}
 are currently not supported and need to be transformed to \code{data.frames} beforehand.}
+
+\item{checkVarNames}{Logical. Should new variable names be checked by \code{\link{checkVarNames}}?}
 }
 \value{
 Returns the original object with updated meta data (and removes factors from the data).

--- a/tests/testthat/test_cloneVariable.R
+++ b/tests/testthat/test_cloneVariable.R
@@ -19,6 +19,16 @@ test_that("Clone variable", {
 
 })
 
+test_that("Clone variable with invalid variable name", {
+  out <- cloneVariable(dfSAV, varName = "VAR1", new_varName = "Alter", checkVarName = FALSE)
+  expect_equal(namesGADS(out), c("VAR1", "VAR2", "VAR3", "Alter"))
+  expect_equal(out$dat$VAR1, out$dat$Alter)
+
+  expect_message(out2 <- cloneVariable(dfSAV, varName = "VAR1", new_varName = "Alter", checkVarName = TRUE),
+                 "Alter has been renamed to AlterVar")
+  expect_equal(namesGADS(out2), c("VAR1", "VAR2", "VAR3", "AlterVar"))
+})
+
 test_that("Append varLabel", {
   out <- cloneVariable(dfSAV, varName = "VAR1", new_varName = "VAR1_new", label_suffix = "(recoded)")
   expect_equal(out$labels[c(8:10), 2], rep("Variable 1 (recoded)", 3))

--- a/tests/testthat/test_composeVar.R
+++ b/tests/testthat/test_composeVar.R
@@ -18,7 +18,7 @@ test_that("Errors", {
 })
 
 
-test_that("composeVar", {
+test_that("compose a variable", {
   out <- composeVar(dfSAV2, sourceVars = c("VAR1", "VAR2"), newVar = "newVar", primarySourceVar = "VAR1")
 
   expect_equal(out$dat$newVar, c(1, -99, 1, 2))

--- a/tests/testthat/test_composeVar.R
+++ b/tests/testthat/test_composeVar.R
@@ -6,6 +6,9 @@ load(file = "helper_data.rda")
 # dfSAV <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
 dfSAV <- import_spss(file = "helper_spss_missings.sav")
 
+dfSAV2 <- reuseMeta(dfSAV, varName = "VAR2", other_GADSdat = dfSAV, other_varName = "VAR1")
+dfSAV2$dat[2, "VAR2"] <- -96
+
 
 test_that("Errors", {
   expect_error(composeVar(df1, sourceVars = "ID1", newVar = "newVar", primarySourceVar = "ID1"),
@@ -15,11 +18,18 @@ test_that("Errors", {
 })
 
 
-test_that("works normally", {
-  dfSAV2 <- reuseMeta(dfSAV, varName = "VAR2", other_GADSdat = dfSAV, other_varName = "VAR1")
-  dfSAV2$dat[2, "VAR2"] <- -96
+test_that("composeVar", {
   out <- composeVar(dfSAV2, sourceVars = c("VAR1", "VAR2"), newVar = "newVar", primarySourceVar = "VAR1")
 
   expect_equal(out$dat$newVar, c(1, -99, 1, 2))
   expect_equal(out$labels[1:3, "value"], c(-99, -96, 1))
+})
+
+test_that("composeVar with invalid varName", {
+  expect_message(out <- composeVar(dfSAV2, sourceVars = c("VAR1", "VAR2"), newVar = "Alter", primarySourceVar = "VAR1"),
+                 "Alter has been renamed to AlterVar")
+  expect_equal(out$dat$AlterVar, c(1, -99, 1, 2))
+
+  out2 <- composeVar(dfSAV2, sourceVars = c("VAR1", "VAR2"), newVar = "Alter", primarySourceVar = "VAR1", checkVarName = FALSE)
+  expect_equal(out2$dat$Alter, c(1, -99, 1, 2))
 })

--- a/tests/testthat/test_createVariable.R
+++ b/tests/testthat/test_createVariable.R
@@ -7,9 +7,18 @@ test_that("Errors", {
                "'VAR2' is already an existing variable in the 'GADSdat'.")
 })
 
-test_that("Createa variable", {
+test_that("Create a variable", {
   out <- createVariable(dfSAV, varName = "VAR4")
   expect_equal(namesGADS(out), c("VAR1", "VAR2", "VAR3", "VAR4"))
   expect_equal(out$dat$VAR4, rep(NA, 4))
 })
 
+test_that("Create a variable with invalid variable name", {
+  expect_message(out <- createVariable(dfSAV, varName = "var.1"),
+                 "var.1 has been renamed to var_1")
+  expect_equal(namesGADS(out), c("VAR1", "VAR2", "VAR3", "var_1"))
+  expect_equal(out$dat$var_1, rep(NA, 4))
+
+  out2 <- createVariable(dfSAV, varName = "var.1", checkVarName = FALSE)
+  expect_equal(namesGADS(out2), c("VAR1", "VAR2", "VAR3", "var.1"))
+})

--- a/tests/testthat/test_dummies2char.R
+++ b/tests/testthat/test_dummies2char.R
@@ -20,11 +20,12 @@ test_that("errors", {
 })
 
 
-test_that("dummies 2 characters", {
-  dummy_g2 <- changeValLabels(dummy_g, varName = "d1", value = -99, valLabel = "missing")
-  dummy_g2 <- changeMissings(dummy_g2, varName = "d1", value = -99, missings =  "miss")
+dummy_g2 <- changeValLabels(dummy_g, varName = "d1", value = -99, valLabel = "missing")
+dummy_g2 <- changeMissings(dummy_g2, varName = "d1", value = -99, missings =  "miss")
 
-  out <- dummies2char(dummy_g2, dummies = namesGADS(dummy_g2), dummyValues = c("english", "french", "german"), charNames = c("c1", "c2", "c3"))
+test_that("dummies 2 characters", {
+  out <- dummies2char(dummy_g2, dummies = namesGADS(dummy_g2), dummyValues = c("english", "french", "german"),
+                      charNames = c("c1", "c2", "c3"))
   expect_equal(as.character(out$dat[1, 4:6]), c("english", "french", NA))
   expect_equal(as.character(out$dat[2, 4:6]), c("french", "german", NA))
   expect_equal(as.character(out$dat[3, 4:6]), c("english", NA, NA))
@@ -36,4 +37,13 @@ test_that("dummies 2 characters", {
   expect_equal(extractMeta(out, "c2")$missings, NA_character_)
 })
 
+test_that("dummies 2 characters with invalid charNames", {
+  expect_message(out <- dummies2char(dummy_g2, dummies = namesGADS(dummy_g2), dummyValues = c("english", "french", "german"),
+                      charNames = c("v_1", "v.2", "v_3")),
+                 "v.2 has been renamed to v_2")
+  expect_equal(namesGADS(out)[5], c("v_2"))
 
+  out2 <- dummies2char(dummy_g2, dummies = namesGADS(dummy_g2), dummyValues = c("english", "french", "german"),
+                                     charNames = c("v_1", "v.2", "v_3"), checkVarNames = FALSE)
+  expect_equal(namesGADS(out2)[5], c("v.2"))
+})

--- a/tests/testthat/test_getChangeMeta.R
+++ b/tests/testthat/test_getChangeMeta.R
@@ -19,7 +19,7 @@ test_that("Extract variable level meta change table", {
 test_that("check_varChanges", {
   changes_var2 <-changes_var1 <- changes_var
   changes_var1$varName_new[1] <- "alter"
-  expect_message(out <- check_varChanges(changes_var1),
+  expect_message(out <- check_varChanges(changes_var1, checkVarNames = TRUE),
                  "alter has been renamed to alterVar")
   expect_equal(out[1, "varName_new"], "alterVar")
 

--- a/tests/testthat/test_updateMeta.R
+++ b/tests/testthat/test_updateMeta.R
@@ -11,7 +11,6 @@ newDat <- df1$dat
 newDat$v3 <- c(4, 5)
 newDat$V1 <- NULL
 
-
 test_that("Remove rows meta helper", {
   expect_message(remove_rows_meta(df1$labels, names(newDat)), "Removing the following rows from meta data: V1")
   expect_equal(suppressMessages(remove_rows_meta(df1$labels, names(newDat))), df1$labels[df1$labels$varName == "ID1", ])
@@ -57,7 +56,7 @@ test_that("Update Meta all_GADSdat", {
   expect_equal(changes_out$allLabels$varName, c("ID1", "v3", "ID1", "V2", "v5", "v5"))
 })
 
-test_that("Invalid variable names are check and changed", {
+test_that("Invalid variable names are checked and changed", {
   newDat_ill <- df1$dat
   newDat_ill[, "Alter"] <- NA
   mess <- capture_messages(out_both <- updateMeta(df1, newDat_ill))

--- a/tests/testthat/test_updateMeta.R
+++ b/tests/testthat/test_updateMeta.R
@@ -21,11 +21,13 @@ test_that("Remove rows meta helper", {
 })
 
 test_that("Add rows to meta helper", {
-  expect_message(add_rows_meta(df1$labels, newDat), "Adding meta data for the following variables: v3")
-  expect_equal(suppressMessages(add_rows_meta(df1$labels, newDat)), import_DF(newDat[, "v3", drop = F]))
+  expect_message(out <- add_rows_meta(df1$labels, newDat, checkVarNames = FALSE),
+                 "Adding meta data for the following variables: v3")
+  expect_equal(out, import_DF(newDat[, "v3", drop = F]))
 
-  expect_message(add_rows_meta(df1$labels, df1$dat), "No rows added to meta data.")
-  expect_equal(suppressMessages(add_rows_meta(df1$labels, df1$dat)), new_GADSdat(dat = data.frame(), labels = data.frame()))
+  expect_message(out2 <- add_rows_meta(df1$labels, df1$dat, checkVarNames = FALSE),
+                 "No rows added to meta data.")
+  expect_equal(out2, new_GADSdat(dat = data.frame(), labels = data.frame()))
 })
 
 
@@ -55,14 +57,14 @@ test_that("Update Meta all_GADSdat", {
   expect_equal(changes_out$allLabels$varName, c("ID1", "v3", "ID1", "V2", "v5", "v5"))
 })
 
-test_that("Invalid variable names are no longer changed", {
+test_that("Invalid variable names are check and changed", {
   newDat_ill <- df1$dat
   newDat_ill[, "Alter"] <- NA
-  #mess <- capture_messages(out_both <- updateMeta(df1, newDat_ill))
-  #expect_equal(mess[2], "Alter has been renamed to AlterVar\n")
-  #expect_equal(names(out_both$dat), c("ID1", "V1", "AlterVar"))
-  out_both <- updateMeta(df1, newDat_ill)
-  expect_equal(names(out_both$dat), c("ID1", "V1", "Alter"))
+  mess <- capture_messages(out_both <- updateMeta(df1, newDat_ill))
+  expect_equal(mess[2], "Alter has been renamed to AlterVar\n")
+  expect_equal(names(out_both$dat), c("ID1", "V1", "AlterVar"))
+  #out_both <- updateMeta(df1, newDat_ill)
+  #expect_equal(names(out_both$dat), c("ID1", "V1", "Alter"))
 })
 
 test_that("updateMeta extractData combination", {

--- a/tests/testthat/test_updateMeta.R
+++ b/tests/testthat/test_updateMeta.R
@@ -55,12 +55,14 @@ test_that("Update Meta all_GADSdat", {
   expect_equal(changes_out$allLabels$varName, c("ID1", "v3", "ID1", "V2", "v5", "v5"))
 })
 
-test_that("illegal variable names", {
+test_that("Invalid variable names are no longer changed", {
   newDat_ill <- df1$dat
   newDat_ill[, "Alter"] <- NA
-  mess <- capture_messages(out_both <- updateMeta(df1, newDat_ill))
-  expect_equal(mess[2], "Alter has been renamed to AlterVar\n")
-  expect_equal(names(out_both$dat), c("ID1", "V1", "AlterVar"))
+  #mess <- capture_messages(out_both <- updateMeta(df1, newDat_ill))
+  #expect_equal(mess[2], "Alter has been renamed to AlterVar\n")
+  #expect_equal(names(out_both$dat), c("ID1", "V1", "AlterVar"))
+  out_both <- updateMeta(df1, newDat_ill)
+  expect_equal(names(out_both$dat), c("ID1", "V1", "Alter"))
 })
 
 test_that("updateMeta extractData combination", {


### PR DESCRIPTION
(sorry, this is a bigger one...)

This PR addresses issue #46. The root cause is inconsistent name validation (names are checked to comply to `SQLite` standards, see also the `checkVarNames()` documentation). In the past, some functions had optional checks, some functions always performed checks and some functions did not perform checks at all.

The new standards are:
- all import functions have optional name checking (`checkVarNames` argument; stays as it was)
- all name changing functions (`changeVarNames()` and `applyChangeMeta()`) have optional name checking (`checkVarNames` argument; new feature)
- all functions for adding variables to GADSdat objects (`updateMeta()`, `cloneVariable()`, `createVariable()`, `composeVar()`, `dummies2char()`) have optional name checking (new feature, ; new feature)
- all functions which add variables via suffices etc. (e.g., `multiChar2fac()`) do NOT have optional name checking (stays at is was)

Even though this creates (often unnecessary) overhead for functions such as `composeVar()`, this was IMO the simplest and least intrusive way to standardize things.

