### PR TITLE
pre-sorting data for equalGADS()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.0.0.9000
 
 ## new features
+* `equalGADS()` now allows pre-sorting the data by an identifier variable
 * `updateMeta()`, `applyChangeMeta()`, `changeVarNames()`, `cloneVariable()`, `createVariable()`, `composeVar()`, and `dummies2char()` now have optional checks of new variables names via the `checkVarNames` argument
 * `reuseMeta()` now can be use on multiple variables at once
 * `inspectMetaDifferences()` now can be applied to data bases as well

--- a/R/equalGADS.R
+++ b/R/equalGADS.R
@@ -10,6 +10,8 @@
 #'
 #'@param target A \code{GADSdat} object.
 #'@param current A \code{GADSdat} object.
+#'@param id A character vector of length 1 containing the unique identifier column of both \code{GADSdat}.
+#'If specified, both \code{GADSdat} are ordered according to \code{ID} before comparing their data.
 #'@param metaExceptions Should certain meta data columns be excluded from the comparison?
 #'@param tolerance A numeric value greater than or equal to \code{0}. Differences smaller than \code{tolerance} are not reported.
 #'The default value is close to \code{1.5e-8}.
@@ -18,19 +20,32 @@
 #'
 #'
 #'@export
-equalGADS <- function(target, current, metaExceptions = c("display_width", "labeled"), tolerance = sqrt(.Machine$double.eps)) {
+equalGADS <- function(target, current, id = NULL,
+                      metaExceptions = c("display_width", "labeled"), tolerance = sqrt(.Machine$double.eps)) {
   UseMethod("equalGADS")
 }
 #'@export
-equalGADS.GADSdat <- function(target, current, metaExceptions = c("display_width", "labeled"), tolerance = sqrt(.Machine$double.eps)) {
+equalGADS.GADSdat <- function(target, current, id = NULL,
+                              metaExceptions = c("display_width", "labeled"), tolerance = sqrt(.Machine$double.eps)) {
   check_GADSdat(target)
   check_GADSdat(current)
-  if(!(is.null(metaExceptions) || is.character(metaExceptions))) stop("'metaExceptions' must be NULL or a character vector.")
-  if(any(!metaExceptions %in% c("varLabel", 'format', 'display_width', 'valLabel', 'missings', 'labeled'))) stop("Entries in 'metaExceptions' can only be 'varLabel', 'format', 'display_width', 'labeled', 'valLabel', and 'missings'.")
+  if(!(is.null(metaExceptions) || is.character(metaExceptions))) {
+    stop("'metaExceptions' must be NULL or a character vector.")
+  }
+  if(any(!metaExceptions %in% c("varLabel", 'format', 'display_width', 'valLabel', 'missings', 'labeled'))) {
+    stop("Entries in 'metaExceptions' can only be 'varLabel', 'format', 'display_width', 'labeled', 'valLabel', and 'missings'.")
+  }
+  # sort if possible
+  if(!is.null(id)) {
+    check_vars_in_GADSdat(target, vars = id, argName = "id", GADSdatName = "target")
+    check_vars_in_GADSdat(current, vars = id, argName = "id", GADSdatName = "current")
+
+    target$dat <- target$dat[order(target$dat[, id]), ]
+    current$dat <- current$dat[order(current$dat[, id]), ]
+  }
 
   out <- list()
 
-  #browser()
   # variable names
   target_names <- namesGADS(target)
   current_names <- namesGADS(current)

--- a/man/equalGADS.Rd
+++ b/man/equalGADS.Rd
@@ -7,6 +7,7 @@
 equalGADS(
   target,
   current,
+  id = NULL,
   metaExceptions = c("display_width", "labeled"),
   tolerance = sqrt(.Machine$double.eps)
 )
@@ -15,6 +16,9 @@ equalGADS(
 \item{target}{A \code{GADSdat} object.}
 
 \item{current}{A \code{GADSdat} object.}
+
+\item{id}{A character vector of length 1 containing the unique identifier column of both \code{GADSdat}.
+If specified, both \code{GADSdat} are ordered according to \code{ID} before comparing their data.}
 
 \item{metaExceptions}{Should certain meta data columns be excluded from the comparison?}
 

--- a/tests/testthat/test_equalGADS.R
+++ b/tests/testthat/test_equalGADS.R
@@ -28,12 +28,23 @@ test_that("Compare two identical GADSdat objects",{
   expect_equal(out$data_nrow, "all.equal")
 })
 
-test_that("Compare while ignoring order differences",{
+test_that("Compare while ignoring order differences for meta data",{
   dfSAV2 <- dfSAV
   dfSAV2$labels <- dfSAV2$labels[c(2:1, 3:7), ]
   out <- equalGADS(dfSAV, dfSAV2)
   expect_equal(out$meta_data_differences, character())
 })
+
+test_that("Compare while ignoring order differences for data",{
+  dfSAV2 <- dfSAV
+  dfSAV2$dat <- dfSAV2$dat[c(2, 4, 3, 1), ]
+  out <- equalGADS(dfSAV, dfSAV2)
+  expect_equal(out$data_differences, c("VAR1", "VAR3"))
+
+  out2 <- equalGADS(dfSAV, dfSAV2, id = "VAR1")
+  expect_equal(out2$data_differences, character())
+})
+
 
 test_that("Compare while ignoring irrelevant format differences",{
   dfSAV2 <- changeSPSSformat(dfSAV, "VAR1", format = "F8")


### PR DESCRIPTION
`equalGADS()` reports differences between two `GADSdat` objects. Frequently, the cause for differences on the data level is the fact, that in both objects data is differently sorted. Via a new `id` argument, both data sets can now be sorted before comparing them.

This PR closes #2 (original feature request by @enkeflor)

@nickhaf :
As @franikowsp has been frequently reviewing rather big PRs, maybe you can take on this (rather small) one? 