### PR TITLE
bug fix extractData and extractData2

### DIFF
--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -147,34 +147,29 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
                                  convertMiss = convertMiss))
     change_labels <- change_labels[!change_labels$varName %in% drop_labels, ]
   }
-  # convert labels into values
-  changed_variables <- character(0)
   # early return, if no values are to be recoded
   if(nrow(change_labels) == 0) return(dat)
-  # recode values
-  for(i in seq(nrow(change_labels))) {
-    curRow <- change_labels[i, , drop = FALSE]
-    #browser()
-    if(!is.na(curRow$valLabel)) {
-      ## preserve numeric type of variable if possible (although not sure whether this could realistically be the case...)
-      curRow$valLabel <- suppressWarnings(eatTools::asNumericIfPossible(curRow$valLabel, force.string = FALSE))
-      # so far fastest: maybe car? mh...
-      dat[which(dat[, curRow$varName] == curRow$value), curRow$varName] <- curRow$valLabel
-      # dat[, curRow$varName] <- ifelse(dat[, curRow$varName] == curRow$value, curRow$valLabel, dat[, curRow$varName])
-      changed_variables <- unique(c(curRow$varName, changed_variables))
-    }
-  }
+
+  # convert labels into values (use recode function from applyChangeMeta)
+  change_table <- change_labels[, c("varName", "value", "valLabel")]
+  names(change_table) <- c("varName", "value", "value_new")
+  dat2 <- recode_dat(dat, changeTable = change_table)
+
+  # identify modified variables
+  is_character_old <- unlist(lapply(dat, function(var) is.character(var)))
+  is_character_new <- unlist(lapply(dat2, function(var) is.character(var)))
+  changed_variables <- names(dat2)[is_character_new & !is_character_old]
 
   # convert characters to factor if specified (keep ordering if possible)
   #if(!is.null(labels2ordered)) browser()
   changed_variables_labels2factor <- intersect(labels2factor, changed_variables)
   changed_variables <- setdiff(changed_variables, changed_variables_labels2factor)
   if(length(changed_variables_labels2factor) > 0) {
-    dat <- char2fac(dat = dat, labels = labels, vars = changed_variables_labels2factor, convertMiss = convertMiss, ordered = FALSE)
+    dat2 <- char2fac(dat = dat2, labels = labels, vars = changed_variables_labels2factor, convertMiss = convertMiss, ordered = FALSE)
   }
   changed_variables_labels2ordered <- intersect(labels2ordered, changed_variables)
   if(length(changed_variables_labels2ordered) > 0) {
-    dat <- char2fac(dat = dat, labels = labels, vars = changed_variables_labels2ordered, convertMiss = convertMiss, ordered = TRUE)
+    dat2 <- char2fac(dat = dat2, labels = labels, vars = changed_variables_labels2ordered, convertMiss = convertMiss, ordered = TRUE)
   }
-  dat
+  dat2
 }

--- a/tests/testthat/test_extractData.R
+++ b/tests/testthat/test_extractData.R
@@ -135,6 +135,14 @@ test_that("Correct behavior if not all value labels in actual values", {
   expect_equal(as.numeric(dat$v1), c(1, 2, 1))
 })
 
+test_that("Correct behavior if values are being recoded into then to be recoded values", {
+  dat <- data.frame(v1 = c(1, 2, 98, 99))
+  gads <- import_DF(dat)
+  gads2 <- changeValLabels(gads, "v1", value = c(1, 2, 98, 99),
+                           valLabel = c(98, 99, "missing 1", "missing 2"))
+  out <- extractData(gads2)
+  expect_equal(out[[1]], c(98, 99, "missing 1", "missing 2"))
+})
 
 mixed_values <- new_GADSdat(dat = data.frame(x = 0, y = 1, stringsAsFactors = FALSE),
                             labels = data.frame(varName = c("x", "y"),

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -154,6 +154,14 @@ test_that("Correct behavior if not all value labels in actual values", {
   expect_equal(as.numeric(dat$v1), c(1, 2, 1))
 })
 
+test_that("Correct behavior if values are being recoded into then to be recoded values", {
+  dat <- data.frame(v1 = c(1, 2, 98, 99))
+  gads <- import_DF(dat)
+  gads2 <- changeValLabels(gads, "v1", value = c(1, 2, 98, 99),
+                           valLabel = c(98, 99, "missing 1", "missing 2"))
+  out <- extractData2(gads2, labels2character = namesGADS(gads2))
+  expect_equal(out[[1]], c(98, 99, "missing 1", "missing 2"))
+})
 
 mixed_values <- new_GADSdat(dat = data.frame(x = 0, y = 1, stringsAsFactors = FALSE),
                             labels = data.frame(varName = c("x", "y"),


### PR DESCRIPTION
This PR adresses #55, a bug in `extractData()` and `extractData2()` which led to flawed value label application. 

Internally, the recoding is now done by `recode_dat()`, a function used within the `applyChangeMeta()` framework. `recode_dat()` should be the function that is used internally for data recoding at all places in the future and could be the angle for performance improvements in the future. Currently, an alternative framework is implemented in `applyLookup()`. This could be integrated somewhen in the future.

@sachseka & @franikowsp:
One review is sufficient, feel free to assign yourself whoever is interested/available.