### PR TITLE
inspectDifferences and inspectMetaDifferences within a GADSdat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # eatGADS 1.1.0.9000
+## new features
+* `inspectDifferences()` and `inspectMetaDifferences()` now allow comparisons of variables within the same `GADSdat` object (#62)
+
 ## bug fixes
 * `applyChangeMeta()` and `recodeGADS()` now correctly perform recodings (and throw errors) if multiple meta data conflicts occur (#57)
 

--- a/R/inspectDifferences.R
+++ b/R/inspectDifferences.R
@@ -2,16 +2,19 @@
 #############################################################################
 #' Inspect differences in a variable.
 #'
-#' Inspect differences between two \code{GADSdat} objects in a specific variable.
+#' Inspect differences within a single \code{GADSdat} or between two \code{GADSdat} objects for a specific variable.
 #'
 #' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
 #' If differences in the data for specific variables in the two objects occur,
-#' these variables can be further inspected using \code{inspectDifferences}. Differences on meta data-level can be inspected via
-#' \code{\link{inspectMetaDifferences}}.
+#' these variables can be further inspected using \code{inspectDifferences}.
+#' Differences on meta data-level can be inspected via \code{\link{inspectMetaDifferences}}.
 #'
+#'@param GADSdat A \code{GADSdat} object.
 #'@param varName A character vector of length 1 containing the variable name.
-#'@param GADSdat1 A \code{GADSdat} object.
-#'@param GADSdat2 A \code{GADSdat} object.
+#'@param other_GADSdat A second \code{GADSdat} object. If omitted, it is assumed that both variables are part of the
+#'first \code{GADSdat}.
+#'@param other_varName A character vector of length 1 containing the other variable name.
+#'If omitted, it is assumed that both variables have identical names (as supplied in \code{varName}).
 #'@param id A character vector of length 1 containing the unique identifier column of both \code{GADSdat}.
 #'
 #'@return A list.
@@ -25,43 +28,45 @@
 #' equalGADS(pisa, pisa2)
 #'
 #' # inspect via inspectDifferences()
-#' inspectDifferences("age", GADSdat1 = pisa, GADSdat2 = pisa2, id = "idstud")
+#' inspectDifferences(GADSdat = pisa, varName = "age", other_GADSdat = pisa2, id = "idstud")
 #'
 #'@export
-inspectDifferences <- function(varName, GADSdat1, GADSdat2, id) {
-  check_GADSdat(GADSdat1)
-  check_GADSdat(GADSdat2)
-  if(!is.character(varName) || length(varName) != 1) stop("'varName' must be a character of length 1.")
-  if(!is.character(id) || length(id) != 1) stop("'id' must be a character of length 1.")
-  if(!varName %in% namesGADS(GADSdat1)) stop("'varName' is not a variable in 'GADSdat1'.")
-  if(!varName %in% namesGADS(GADSdat2)) stop("'varName' is not a variable in 'GADSdat2'.")
-  if(!id %in% namesGADS(GADSdat1)) stop("'id' is not a variable in 'GADSdat1'.")
-  if(!id %in% namesGADS(GADSdat2)) stop("'id' is not a variable in 'GADSdat2'.")
-  if(nrow(GADSdat1$dat) != nrow(GADSdat2$dat)) stop("'GADSdat1' and 'GADSdat2' have different row numbers.")
-  if(any(is.na(GADSdat1$dat[, id]))) stop("Missing values in 'id' column of 'GADSdat1'.")
-  if(any(is.na(GADSdat2$dat[, id]))) stop("Missing values in 'id' column of 'GADSdat2'.")
-  if(any(GADSdat1$dat[, id] != GADSdat2$dat[, id])) stop("'id' column is not equal for 'GADSdat1' and 'GADSdat2'.")
+inspectDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, other_varName = varName, id) {
+  check_GADSdat(GADSdat)
+  check_GADSdat(other_GADSdat)
+  check_characterArgument(varName, argName = "varName")
+  check_characterArgument(other_varName, argName = "other_varName")
+  check_characterArgument(id, argName = "id")
+  check_vars_in_GADSdat(GADSdat, vars = varName, argName = "varName", GADSdatName = "GADSdat")
+  check_vars_in_GADSdat(other_GADSdat, vars = other_varName, argName = "other_varName", GADSdatName = "other_GADSdat")
+  check_vars_in_GADSdat(GADSdat, vars = id, argName = "id", GADSdatName = "GADSdat")
+  check_vars_in_GADSdat(other_GADSdat, vars = id, argName = "id", GADSdatName = "other_GADSdat")
 
-  if(is.numeric(GADSdat1$dat[, varName]) && !is.numeric(GADSdat2$dat[, varName])) stop("'varName' column is numeric in 'GADSdat1' but not in 'GADSdat2'.")
-  if(!is.numeric(GADSdat1$dat[, varName]) && is.numeric(GADSdat2$dat[, varName])) stop("'varName' column is numeric in 'GADSdat2' but not in 'GADSdat1'.")
+  if(nrow(GADSdat$dat) != nrow(other_GADSdat$dat)) stop("'GADSdat' and 'other_GADSdat' have different row numbers.")
+  if(any(is.na(GADSdat$dat[, id]))) stop("Missing values in 'id' column of 'GADSdat'.")
+  if(any(is.na(other_GADSdat$dat[, id]))) stop("Missing values in 'id' column of 'other_GADSdat'.")
+  if(any(GADSdat$dat[, id] != other_GADSdat$dat[, id])) stop("'id' column is not equal for 'GADSdat' and 'other_GADSdat'.")
 
-  if(isTRUE(all.equal(GADSdat2$dat[, varName], GADSdat1$dat[, varName], scale = 1))) return("all.equal")
+  if(is.numeric(GADSdat$dat[, varName]) && !is.numeric(other_GADSdat$dat[, varName])) stop("'varName' column is numeric in 'GADSdat' but not in 'other_GADSdat'.")
+  if(!is.numeric(GADSdat$dat[, varName]) && is.numeric(other_GADSdat$dat[, varName])) stop("'varName' column is numeric in 'other_GADSdat' but not in 'GADSdat'.")
 
-  unequal_rows <- c(which(GADSdat2$dat[, varName] != GADSdat1$dat[, varName]),
-                    which(is.na(GADSdat2$dat[, varName]) & !is.na(GADSdat1$dat[, varName])),
-                    which(!is.na(GADSdat2$dat[, varName]) & is.na(GADSdat1$dat[, varName])))
-  unequal_case_dat2 <- GADSdat2$dat[unequal_rows, ]
-  unequal_case_dat1 <- GADSdat1$dat[unequal_rows, ]
+  if(isTRUE(all.equal(GADSdat$dat[, varName], other_GADSdat$dat[, varName], scale = 1))) return("all.equal")
 
-  ncol1 <- ifelse(ncol(GADSdat1$dat) > 8, yes = 8, no = ncol(GADSdat1$dat))
-  ncol2 <- ifelse(ncol(GADSdat2$dat) > 8, yes = 8, no = ncol(GADSdat2$dat))
+  unequal_rows <- c(which(other_GADSdat$dat[, varName] != GADSdat$dat[, varName]),
+                    which(is.na(other_GADSdat$dat[, varName]) & !is.na(GADSdat$dat[, varName])),
+                    which(!is.na(other_GADSdat$dat[, varName]) & is.na(GADSdat$dat[, varName])))
+  unequal_case_dat2 <- other_GADSdat$dat[unequal_rows, ]
+  unequal_case_dat1 <- GADSdat$dat[unequal_rows, ]
+
+  ncol1 <- ifelse(ncol(GADSdat$dat) > 8, yes = 8, no = ncol(GADSdat$dat))
+  ncol2 <- ifelse(ncol(other_GADSdat$dat) > 8, yes = 8, no = ncol(other_GADSdat$dat))
   nrow1 <- ifelse(nrow(unequal_case_dat1) > 5, yes = 5, no = nrow(unequal_case_dat1))
   nrow2 <- ifelse(nrow(unequal_case_dat2) > 5, yes = 5, no = nrow(unequal_case_dat2))
 
-  list(cross_table = table(GADSdat1$dat[, varName], GADSdat2$dat[, varName], useNA = "if",
+  list(cross_table = table(GADSdat$dat[, varName], other_GADSdat$dat[, varName], useNA = "if",
                            dnn = c("GADSdat1", "GADSdat2")),
-       some_unequals_GADSdat1 = unequal_case_dat1[1:nrow1, unique(c(namesGADS(GADSdat1)[1:ncol1], varName))],
-       some_unequals_GADSdat2 = unequal_case_dat2[1:nrow2, unique(c(namesGADS(GADSdat2)[1:ncol2], varName))],
+       some_unequals_GADSdat1 = unequal_case_dat1[1:nrow1, unique(c(namesGADS(GADSdat)[1:ncol1], varName))],
+       some_unequals_GADSdat2 = unequal_case_dat2[1:nrow2, unique(c(namesGADS(other_GADSdat)[1:ncol2], varName))],
        unequal_IDs = unequal_case_dat2[, id]
   )
 }

--- a/R/inspectDifferences.R
+++ b/R/inspectDifferences.R
@@ -64,15 +64,14 @@ inspectDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, other_
   unequal_case_dat2 <- other_GADSdat$dat[unequal_rows, ]
   unequal_case_dat1 <- GADSdat$dat[unequal_rows, ]
 
-  ncol1 <- ifelse(ncol(GADSdat$dat) > 8, yes = 8, no = ncol(GADSdat$dat))
-  ncol2 <- ifelse(ncol(other_GADSdat$dat) > 8, yes = 8, no = ncol(other_GADSdat$dat))
-  nrow1 <- ifelse(nrow(unequal_case_dat1) > 5, yes = 5, no = nrow(unequal_case_dat1))
-  nrow2 <- ifelse(nrow(unequal_case_dat2) > 5, yes = 5, no = nrow(unequal_case_dat2))
+  # naming for cross_table
+  nam_dnn <- c(varName, other_varName)
+  if(identical(varName, other_varName)) {
+    nam_dnn <- c("GADSdat", "other_GADSdat")
+  }
 
   list(cross_table = table(GADSdat$dat[, varName], other_GADSdat$dat[, other_varName], useNA = "if",
-                           dnn = c("GADSdat1", "GADSdat2")),
-       some_unequals_GADSdat1 = unequal_case_dat1[1:nrow1, unique(c(namesGADS(GADSdat)[1:ncol1], varName))],
-       some_unequals_GADSdat2 = unequal_case_dat2[1:nrow2, unique(c(namesGADS(other_GADSdat)[1:ncol2], other_varName))],
+                           dnn = nam_dnn),
        unequal_IDs = unequal_case_dat2[, id]
   )
 }

--- a/R/inspectDifferences.R
+++ b/R/inspectDifferences.R
@@ -47,14 +47,20 @@ inspectDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, other_
   if(any(is.na(other_GADSdat$dat[, id]))) stop("Missing values in 'id' column of 'other_GADSdat'.")
   if(any(GADSdat$dat[, id] != other_GADSdat$dat[, id])) stop("'id' column is not equal for 'GADSdat' and 'other_GADSdat'.")
 
-  if(is.numeric(GADSdat$dat[, varName]) && !is.numeric(other_GADSdat$dat[, varName])) stop("'varName' column is numeric in 'GADSdat' but not in 'other_GADSdat'.")
-  if(!is.numeric(GADSdat$dat[, varName]) && is.numeric(other_GADSdat$dat[, varName])) stop("'varName' column is numeric in 'other_GADSdat' but not in 'GADSdat'.")
+  if(is.numeric(GADSdat$dat[, varName]) && !is.numeric(other_GADSdat$dat[, other_varName])) {
+    stop("'varName' column is numeric in 'GADSdat' but 'other_varName' is not numeric in 'other_GADSdat'.")
+  }
+  if(!is.numeric(GADSdat$dat[, varName]) && is.numeric(other_GADSdat$dat[, other_varName])) {
+    stop("'other_varName' column is numeric in 'other_GADSdat' but 'varName' is not numeric in 'GADSdat'.")
+  }
 
-  if(isTRUE(all.equal(GADSdat$dat[, varName], other_GADSdat$dat[, varName], scale = 1))) return("all.equal")
+  if(isTRUE(all.equal(GADSdat$dat[, varName], other_GADSdat$dat[, other_varName], scale = 1))) {
+    return("all.equal")
+  }
 
-  unequal_rows <- c(which(other_GADSdat$dat[, varName] != GADSdat$dat[, varName]),
-                    which(is.na(other_GADSdat$dat[, varName]) & !is.na(GADSdat$dat[, varName])),
-                    which(!is.na(other_GADSdat$dat[, varName]) & is.na(GADSdat$dat[, varName])))
+  unequal_rows <- c(which(other_GADSdat$dat[, other_varName] != GADSdat$dat[, varName]),
+                    which(is.na(other_GADSdat$dat[, other_varName]) & !is.na(GADSdat$dat[, varName])),
+                    which(!is.na(other_GADSdat$dat[, other_varName]) & is.na(GADSdat$dat[, varName])))
   unequal_case_dat2 <- other_GADSdat$dat[unequal_rows, ]
   unequal_case_dat1 <- GADSdat$dat[unequal_rows, ]
 
@@ -63,10 +69,10 @@ inspectDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, other_
   nrow1 <- ifelse(nrow(unequal_case_dat1) > 5, yes = 5, no = nrow(unequal_case_dat1))
   nrow2 <- ifelse(nrow(unequal_case_dat2) > 5, yes = 5, no = nrow(unequal_case_dat2))
 
-  list(cross_table = table(GADSdat$dat[, varName], other_GADSdat$dat[, varName], useNA = "if",
+  list(cross_table = table(GADSdat$dat[, varName], other_GADSdat$dat[, other_varName], useNA = "if",
                            dnn = c("GADSdat1", "GADSdat2")),
        some_unequals_GADSdat1 = unequal_case_dat1[1:nrow1, unique(c(namesGADS(GADSdat)[1:ncol1], varName))],
-       some_unequals_GADSdat2 = unequal_case_dat2[1:nrow2, unique(c(namesGADS(other_GADSdat)[1:ncol2], varName))],
+       some_unequals_GADSdat2 = unequal_case_dat2[1:nrow2, unique(c(namesGADS(other_GADSdat)[1:ncol2], other_varName))],
        unequal_IDs = unequal_case_dat2[, id]
   )
 }

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -42,15 +42,15 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
   meta2 <- extractMeta(other_GADSdat, other_varName)
 
   ## Variable level
-  metaVar1 <- meta1[1, c("varName", "varLabel", "format")]
-  metaVar2 <- meta2[1, c("varName", "varLabel", "format")]
+  metaVar1 <- meta1[1, c("varLabel", "format")]
+  metaVar2 <- meta2[1, c("varLabel", "format")]
   row.names(metaVar1) <- row.names(metaVar2) <- NULL
 
   varDiff <- NULL
   if(!identical(metaVar1, metaVar2)) {
     varDiff <- data.frame(varName = varName,
-                          GADS1 = metaVar1[, 2:3],
-                          GADS2 = metaVar2[, 2:3])
+                          GADS1 = metaVar1,
+                          GADS2 = metaVar2)
   }
 
   ## Value level
@@ -58,8 +58,12 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
   metaVal2 <- meta2[, c("varName", "value", "valLabel", "missings")]
   row.names(metaVal1) <- row.names(metaVal2) <- NULL
 
+  # hotfix, this should be properly fixed someday
+  metaVal1$value <- as.numeric(metaVal1$value)
+  metaVal2$value <- as.numeric(metaVal2$value)
+
   valDiff <- NULL
-  if(!identical(metaVal1, metaVal2)) {
+  if(!identical(metaVal1[, c("value", "valLabel", "missings")], metaVal2[, c("value", "valLabel", "missings")])) {
     all_values <- unique(stats::na.omit(c(metaVal1$value, metaVal2$value)))
     for(val in all_values) {
       #browser()

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -2,17 +2,21 @@
 #############################################################################
 #' Inspect meta data differences in a variable.
 #'
-#' Inspect meta data differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
+#' Inspect meta data differences within a single \code{GADSdat} or between two \code{GADSdat} objects
+#' or \code{GADSdat} data bases regarding a specific variable.
 #'
 #' Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
 #' If meta data differences for specific variables in the two objects occur,
 #' these variables can be further inspected using \code{inspectMetaDifferences}.
 #' For data-level differences for a specific variable, see \code{\link{inspectDifferences}}.
 #'
+#'@param GADSdat A \code{GADSdat} object.
 #'@param varName A character vector of length 1 containing the variable name.
-#'@param GADSdat1 A \code{GADSdat} object.
-#'@param GADSdat2 A \code{GADSdat} object.
-
+#'@param other_GADSdat A second \code{GADSdat} object. If omitted, it is assumed that both variables are part of the
+#'first \code{GADSdat}.
+#'@param other_varName A character vector of length 1 containing the other variable name.
+#'If omitted, it is assumed that both variables have identical names (as supplied in \code{varName}).
+#'
 #'@return A list.
 #'
 #'@examples
@@ -25,16 +29,17 @@
 #' equalGADS(pisa, pisa2)
 #'
 #' # inspect via inspectMetaDifferences()
-#' inspectMetaDifferences("sameteach", GADSdat1 = pisa, GADSdat2 = pisa2)
+#' inspectMetaDifferences(GADSdat = pisa, varName = "sameteach", other_GADSdat = pisa2)
 #'
 #'@export
-inspectMetaDifferences <- function(varName, GADSdat1, GADSdat2) {
+inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, other_varName = varName) {
   check_characterArgument(varName, argName = "varName")
-  check_vars_in_GADSdat(GADSdat1, vars = varName, argName = "varName", GADSdatName = "GADSdat1")
-  check_vars_in_GADSdat(GADSdat2, vars = varName, argName = "varName", GADSdatName = "GADSdat2")
+  check_characterArgument(other_varName, argName = "other_varName")
+  check_vars_in_GADSdat(GADSdat, vars = varName, argName = "varName", GADSdatName = "GADSdat")
+  check_vars_in_GADSdat(other_GADSdat, vars = other_varName, argName = "other_varName", GADSdatName = "other_GADSdat")
 
-  meta1 <- extractMeta(GADSdat1, varName)
-  meta2 <- extractMeta(GADSdat2, varName)
+  meta1 <- extractMeta(GADSdat, varName)
+  meta2 <- extractMeta(other_GADSdat, other_varName)
 
   ## Variable level
   metaVar1 <- meta1[1, c("varName", "varLabel", "format")]

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -41,16 +41,33 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
   meta1 <- extractMeta(GADSdat, varName)
   meta2 <- extractMeta(other_GADSdat, other_varName)
 
+  # naming for columns in output
+  nam_col <- c(varName, other_varName)
+  if(identical(varName, other_varName)) {
+    nam_col <- c("GADSdat", "other_GADSdat")
+  }
+
   ## Variable level
   metaVar1 <- meta1[1, c("varLabel", "format")]
   metaVar2 <- meta2[1, c("varLabel", "format")]
   row.names(metaVar1) <- row.names(metaVar2) <- NULL
 
-  varDiff <- NULL
+  varDiff <- "all.equal"
   if(!identical(metaVar1, metaVar2)) {
-    varDiff <- data.frame(varName = varName,
-                          GADS1 = metaVar1,
-                          GADS2 = metaVar2)
+    # only return column with differences
+    if(!identical(metaVar1$varLabel, metaVar2$varLabel)) {
+      varDiff <- data.frame(metaVar1$varLabel, metaVar2$varLabel)
+      names(varDiff) <- paste(nam_col, "varLabel", sep = "_")
+      if(!identical(metaVar1$format, metaVar2$format)) {
+        varDiff2 <- data.frame(metaVar1$format, metaVar2$format)
+        names(varDiff) <- paste(nam_col, "format", sep = "_")
+
+        varDiff <- cbind(varDiff, varDiff2)[, c(1, 3, 2, 4)]
+      }
+    } else {
+      varDiff <- data.frame(metaVar1$format, metaVar2$format)
+      names(varDiff) <- paste(nam_col, "format", sep = "_")
+    }
   }
 
   ## Value level
@@ -62,8 +79,12 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
   metaVal1$value <- as.numeric(metaVal1$value)
   metaVal2$value <- as.numeric(metaVal2$value)
 
-  valDiff <- NULL
+  valDiff <- "all.equal"
   if(!identical(metaVal1[, c("value", "valLabel", "missings")], metaVal2[, c("value", "valLabel", "missings")])) {
+    valDiff <- data.frame(value = integer(),
+                          valLabel1 = character(), missings2 = character(),
+                          valLabel2 = character(), missings2 = character())
+
     all_values <- unique(stats::na.omit(c(metaVal1$value, metaVal2$value)))
     for(val in all_values) {
       #browser()
@@ -71,10 +92,13 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
       meta_row2 <- metaVal2[metaVal2$value == val, ]
       if(nrow(meta_row1) == 0) meta_row1[1, ] <- NA
       if(nrow(meta_row2) == 0) meta_row2[1, ] <- NA
-      valDiff_new <- data.frame(varName = varName, value = val, GADS1 = meta_row1[, 3:4], GADS2 = meta_row2[, 3:4])
+      valDiff_new <- data.frame(value = val, meta_row1[, 3:4], meta_row2[, 3:4])
       if(!identical(meta_row1, meta_row2)) valDiff <- rbind(valDiff, valDiff_new)
     }
     valDiff <- valDiff[order(valDiff$value), ]
+    names(valDiff) <- c("value", paste0(nam_col[1], "_valLabel"), paste0(nam_col[1], "_missings"),
+                        paste0(nam_col[2], "_valLabel"), paste0(nam_col[2], "_missings"))
+    rownames(valDiff) <- NULL
   }
 
   list(varDiff = varDiff, valDiff = valDiff)

--- a/man/inspectDifferences.Rd
+++ b/man/inspectDifferences.Rd
@@ -4,14 +4,24 @@
 \alias{inspectDifferences}
 \title{Inspect differences in a variable.}
 \usage{
-inspectDifferences(varName, GADSdat1, GADSdat2, id)
+inspectDifferences(
+  GADSdat,
+  varName,
+  other_GADSdat = GADSdat,
+  other_varName = varName,
+  id
+)
 }
 \arguments{
+\item{GADSdat}{A \code{GADSdat} object.}
+
 \item{varName}{A character vector of length 1 containing the variable name.}
 
-\item{GADSdat1}{A \code{GADSdat} object.}
+\item{other_GADSdat}{A second \code{GADSdat} object. If omitted, it is assumed that both variables are part of the
+first \code{GADSdat}.}
 
-\item{GADSdat2}{A \code{GADSdat} object.}
+\item{other_varName}{A character vector of length 1 containing the other variable name.
+If omitted, it is assumed that both variables have identical names (as supplied in \code{varName}).}
 
 \item{id}{A character vector of length 1 containing the unique identifier column of both \code{GADSdat}.}
 }
@@ -19,13 +29,13 @@ inspectDifferences(varName, GADSdat1, GADSdat2, id)
 A list.
 }
 \description{
-Inspect differences between two \code{GADSdat} objects in a specific variable.
+Inspect differences within a single \code{GADSdat} or between two \code{GADSdat} objects for a specific variable.
 }
 \details{
 Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
 If differences in the data for specific variables in the two objects occur,
-these variables can be further inspected using \code{inspectDifferences}. Differences on meta data-level can be inspected via
-\code{\link{inspectMetaDifferences}}.
+these variables can be further inspected using \code{inspectDifferences}.
+Differences on meta data-level can be inspected via \code{\link{inspectMetaDifferences}}.
 }
 \examples{
 # create a second GADS with different data
@@ -36,6 +46,6 @@ pisa2$dat$age[400:nrow(pisa$dat)] <- sample(pisa2$dat$age[400:nrow(pisa$dat)])
 equalGADS(pisa, pisa2)
 
 # inspect via inspectDifferences()
-inspectDifferences("age", GADSdat1 = pisa, GADSdat2 = pisa2, id = "idstud")
+inspectDifferences(GADSdat = pisa, varName = "age", other_GADSdat = pisa2, id = "idstud")
 
 }

--- a/man/inspectMetaDifferences.Rd
+++ b/man/inspectMetaDifferences.Rd
@@ -4,20 +4,30 @@
 \alias{inspectMetaDifferences}
 \title{Inspect meta data differences in a variable.}
 \usage{
-inspectMetaDifferences(varName, GADSdat1, GADSdat2)
+inspectMetaDifferences(
+  GADSdat,
+  varName,
+  other_GADSdat = GADSdat,
+  other_varName = varName
+)
 }
 \arguments{
+\item{GADSdat}{A \code{GADSdat} object.}
+
 \item{varName}{A character vector of length 1 containing the variable name.}
 
-\item{GADSdat1}{A \code{GADSdat} object.}
+\item{other_GADSdat}{A second \code{GADSdat} object. If omitted, it is assumed that both variables are part of the
+first \code{GADSdat}.}
 
-\item{GADSdat2}{A \code{GADSdat} object.}
+\item{other_varName}{A character vector of length 1 containing the other variable name.
+If omitted, it is assumed that both variables have identical names (as supplied in \code{varName}).}
 }
 \value{
 A list.
 }
 \description{
-Inspect meta data differences between two \code{GADSdat} objects or \code{GADSdat} data bases regarding a specific variable.
+Inspect meta data differences within a single \code{GADSdat} or between two \code{GADSdat} objects
+or \code{GADSdat} data bases regarding a specific variable.
 }
 \details{
 Two \code{GADSdat} objects can be compared using \code{\link{equalGADS}}.
@@ -35,6 +45,6 @@ pisa2 <- recodeGADS(pisa2, varName = "sameteach", oldValues = c(1, 2), newValues
 equalGADS(pisa, pisa2)
 
 # inspect via inspectMetaDifferences()
-inspectMetaDifferences("sameteach", GADSdat1 = pisa, GADSdat2 = pisa2)
+inspectMetaDifferences(GADSdat = pisa, varName = "sameteach", other_GADSdat = pisa2)
 
 }

--- a/tests/testthat/test_inspectDifferences.R
+++ b/tests/testthat/test_inspectDifferences.R
@@ -4,34 +4,34 @@ load(file = "helper_data.rda")
 
 test_that("Errors",{
   df1_5 <- df1_4 <- df1_2 <- df1_3 <- df1
-  expect_error(inspectDifferences(c("1", "2"), df1, df1_2, id = "ID1"),
-               "'varName' must be a character of length 1.")
-  expect_error(inspectDifferences("V1", df1, df1_2, id = 1),
-               "'id' must be a character of length 1.")
-  expect_error(inspectDifferences("V2", df1, df1_2, id = "ID1"),
-               "'varName' is not a variable in 'GADSdat1'.")
+  expect_error(inspectDifferences(df1, varName = c("1", "2"), id = "ID1"),
+               "'varName' needs to be a character vector of length 1.")
+  expect_error(inspectDifferences(df1, varName = "V1", id = 1),
+               "'id' needs to be a character vector of length 1.")
+  expect_error(inspectDifferences(df1, varName = "V2", id = "ID1"),
+               "The following 'varName' are not variables in the GADSdat: V2")
   df1_2$dat <- df1_2$dat[c(1, 1, 2), ]
-  expect_error(inspectDifferences("V1", df1, df1_2, id = "ID1"),
-               "'GADSdat1' and 'GADSdat2' have different row numbers.")
+  expect_error(inspectDifferences(df1, varName = "V1", other_GADSdat = df1_2, id = "ID1"),
+               "'GADSdat' and 'other_GADSdat' have different row numbers.")
   df1_3$dat$ID1 <- c(2, 1)
-  expect_error(inspectDifferences("V1", df1, df1_3, id = "ID1"),
-               "'id' column is not equal for 'GADSdat1' and 'GADSdat2'.")
+  expect_error(inspectDifferences(df1, varName = "V1", other_GADSdat = df1_3, id = "ID1"),
+               "'id' column is not equal for 'GADSdat' and 'other_GADSdat'.")
   df1_4$dat[1, 1] <- NA
-  expect_error(inspectDifferences("V1", df1, df1_4, id = "ID1"),
-               "Missing values in 'id' column of 'GADSdat2'.")
-  expect_error(inspectDifferences("V1", df1_4, df1, id = "ID1"),
-               "Missing values in 'id' column of 'GADSdat1'.")
+  expect_error(inspectDifferences(df1, varName = "V1", other_GADSdat = df1_4, id = "ID1"),
+               "Missing values in 'id' column of 'other_GADSdat'.")
+  expect_error(inspectDifferences(df1_4, varName = "V1", id = "ID1"),
+               "Missing values in 'id' column of 'GADSdat'.")
   df1_5$dat[, 2] <- as.character(df1_5$dat[, 1])
-  expect_error(inspectDifferences("V1", df1, df1_5, id = "ID1"),
-               "'varName' column is numeric in 'GADSdat1' but not in 'GADSdat2'.")
-  expect_error(inspectDifferences("V1", df1_5, df1, id = "ID1"),
-               "'varName' column is numeric in 'GADSdat2' but not in 'GADSdat1'.")
+  expect_error(inspectDifferences(df1, varName = "V1", other_GADSdat = df1_5, id = "ID1"),
+               "'varName' column is numeric in 'GADSdat' but not in 'other_GADSdat'.")
+  expect_error(inspectDifferences(df1_5, varName = "V1", other_GADSdat = df1, id = "ID1"),
+               "'varName' column is numeric in 'other_GADSdat' but not in 'GADSdat'.")
 })
 
 test_that("Compare two different GADSdat objects",{
   df1_2 <- df1
   df1_2$dat[1, 2] <- 9
-  out <- inspectDifferences("V1", df1, df1_2, id = "ID1")
+  out <- inspectDifferences(df1, varName = "V1", other_GADSdat = df1_2, id = "ID1")
   expect_equal(names(out), c("cross_table", "some_unequals_GADSdat1", "some_unequals_GADSdat2", "unequal_IDs"))
   expect_equal(out$unequal_IDs, 1)
   expect_equal(out$some_unequals_GADSdat1, df1$dat[1, ])
@@ -40,21 +40,31 @@ test_that("Compare two different GADSdat objects",{
 })
 
 test_that("Compare two identical GADSdat objects",{
-  out <- inspectDifferences("V1", df1, df1, id = "ID1")
+  out <- inspectDifferences(df1, varName = "V1", id = "ID1")
   expect_equal(out, "all.equal")
 })
+
+
+## could potentially be implemented somewhen (see also equalGADS() for similar functionality)
+#test_that("Compare two identical GADSdat objects with different ordering",{
+#  pisa2 <- pisa
+#  pisa2$dat <- pisa2$dat[nrow(pisa2$dat):1, ]
+#  out <- inspectDifferences(pisa, varName = "sameteach", other_GADSdat = pisa2, id = "idstud")
+#  expect_equal(out, "all.equal")
+#})
+
 
 test_that("Differences with NA",{
   df1_3 <- df1_2 <- df1
   df1_2$dat[1, 2] <- NA
-  out <- inspectDifferences("V1", df1, df1_2, id = "ID1")
+  out <- inspectDifferences(df1, varName = "V1", other_GADSdat = df1_2, id = "ID1")
   expect_equal(out$unequal_IDs, 1)
   expect_equal(out$some_unequals_GADSdat1, df1$dat[1, ])
   expect_equal(out$some_unequals_GADSdat2, df1_2$dat[1, ])
   expect_equal(out$cross_table, table(df1$dat$V1, df1_2$dat$V1, useNA = "if", dnn = c("GADSdat1", "GADSdat2")))
 
   df1_3$dat[1:2, 1] <- NA
-  out <- inspectDifferences("ID1", df1_3, df1, id = "V1")
+  out <- inspectDifferences(df1_3, varName = "ID1", other_GADSdat = df1, id = "V1")
   expect_equal(out$unequal_IDs, c(3, 5))
   expect_equal(out$some_unequals_GADSdat1, df1_3$dat[1:2, ])
   expect_equal(out$some_unequals_GADSdat2, df1$dat[1:2, ])

--- a/tests/testthat/test_inspectDifferences.R
+++ b/tests/testthat/test_inspectDifferences.R
@@ -23,12 +23,14 @@ test_that("Errors",{
                "Missing values in 'id' column of 'GADSdat'.")
   df1_5$dat[, 2] <- as.character(df1_5$dat[, 1])
   expect_error(inspectDifferences(df1, varName = "V1", other_GADSdat = df1_5, id = "ID1"),
-               "'varName' column is numeric in 'GADSdat' but not in 'other_GADSdat'.")
+               "'varName' column is numeric in 'GADSdat' but 'other_varName' is not numeric in 'other_GADSdat'.")
   expect_error(inspectDifferences(df1_5, varName = "V1", other_GADSdat = df1, id = "ID1"),
-               "'varName' column is numeric in 'other_GADSdat' but not in 'GADSdat'.")
+               "'other_varName' column is numeric in 'other_GADSdat' but 'varName' is not numeric in 'GADSdat'.")
+  expect_error(inspectDifferences(df1_5, varName = "V1", other_GADSdat = df1, other_varName = "ID1", id = "ID1"),
+               "'other_varName' column is numeric in 'other_GADSdat' but 'varName' is not numeric in 'GADSdat'.")
 })
 
-test_that("Compare two different GADSdat objects",{
+test_that("Compare two different GADSdat objects but the same variable",{
   df1_2 <- df1
   df1_2$dat[1, 2] <- 9
   out <- inspectDifferences(df1, varName = "V1", other_GADSdat = df1_2, id = "ID1")
@@ -38,6 +40,18 @@ test_that("Compare two different GADSdat objects",{
   expect_equal(out$some_unequals_GADSdat2, df1_2$dat[1, ])
   expect_equal(out$cross_table, table(df1$dat$V1, df1_2$dat$V1, dnn = c("GADSdat1", "GADSdat2")))
 })
+
+test_that("Compare two different GADSdat objects and different variables",{
+  df1_2 <- df1
+  df1_2$dat[1, 2] <- 9
+  out <- inspectDifferences(df1, varName = "ID1", other_GADSdat = df1_2, other_varName = "V1", id = "ID1")
+  expect_equal(names(out), c("cross_table", "some_unequals_GADSdat1", "some_unequals_GADSdat2", "unequal_IDs"))
+  expect_equal(out$unequal_IDs, 1:2)
+  expect_equal(out$some_unequals_GADSdat1, df1$dat)
+  expect_equal(out$some_unequals_GADSdat2, df1_2$dat)
+  expect_equal(out$cross_table, table(df1$dat$ID1, df1_2$dat$V1, dnn = c("GADSdat1", "GADSdat2")))
+})
+
 
 test_that("Compare two identical GADSdat objects",{
   out <- inspectDifferences(df1, varName = "V1", id = "ID1")

--- a/tests/testthat/test_inspectDifferences.R
+++ b/tests/testthat/test_inspectDifferences.R
@@ -34,22 +34,17 @@ test_that("Compare two different GADSdat objects but the same variable",{
   df1_2 <- df1
   df1_2$dat[1, 2] <- 9
   out <- inspectDifferences(df1, varName = "V1", other_GADSdat = df1_2, id = "ID1")
-  expect_equal(names(out), c("cross_table", "some_unequals_GADSdat1", "some_unequals_GADSdat2", "unequal_IDs"))
+  expect_equal(names(out), c("cross_table", "unequal_IDs"))
   expect_equal(out$unequal_IDs, 1)
-  expect_equal(out$some_unequals_GADSdat1, df1$dat[1, ])
-  expect_equal(out$some_unequals_GADSdat2, df1_2$dat[1, ])
-  expect_equal(out$cross_table, table(df1$dat$V1, df1_2$dat$V1, dnn = c("GADSdat1", "GADSdat2")))
+  expect_equal(out$cross_table, table(df1$dat$V1, df1_2$dat$V1, dnn = c("GADSdat", "other_GADSdat")))
 })
 
 test_that("Compare two different GADSdat objects and different variables",{
   df1_2 <- df1
   df1_2$dat[1, 2] <- 9
   out <- inspectDifferences(df1, varName = "ID1", other_GADSdat = df1_2, other_varName = "V1", id = "ID1")
-  expect_equal(names(out), c("cross_table", "some_unequals_GADSdat1", "some_unequals_GADSdat2", "unequal_IDs"))
   expect_equal(out$unequal_IDs, 1:2)
-  expect_equal(out$some_unequals_GADSdat1, df1$dat)
-  expect_equal(out$some_unequals_GADSdat2, df1_2$dat)
-  expect_equal(out$cross_table, table(df1$dat$ID1, df1_2$dat$V1, dnn = c("GADSdat1", "GADSdat2")))
+  expect_equal(out$cross_table, table(df1$dat$ID1, df1_2$dat$V1, dnn = c("ID1", "V1")))
 })
 
 
@@ -73,14 +68,12 @@ test_that("Differences with NA",{
   df1_2$dat[1, 2] <- NA
   out <- inspectDifferences(df1, varName = "V1", other_GADSdat = df1_2, id = "ID1")
   expect_equal(out$unequal_IDs, 1)
-  expect_equal(out$some_unequals_GADSdat1, df1$dat[1, ])
-  expect_equal(out$some_unequals_GADSdat2, df1_2$dat[1, ])
-  expect_equal(out$cross_table, table(df1$dat$V1, df1_2$dat$V1, useNA = "if", dnn = c("GADSdat1", "GADSdat2")))
+  expect_equal(out$cross_table,
+               table(df1$dat$V1, df1_2$dat$V1, useNA = "if", dnn = c("GADSdat", "other_GADSdat")))
 
   df1_3$dat[1:2, 1] <- NA
   out <- inspectDifferences(df1_3, varName = "ID1", other_GADSdat = df1, id = "V1")
   expect_equal(out$unequal_IDs, c(3, 5))
-  expect_equal(out$some_unequals_GADSdat1, df1_3$dat[1:2, ])
-  expect_equal(out$some_unequals_GADSdat2, df1$dat[1:2, ])
-  expect_equal(out$cross_table, table(df1_3$dat$ID1, df1$dat$ID1, useNA = "if", dnn = c("GADSdat1", "GADSdat2")))
+  expect_equal(out$cross_table,
+               table(df1_3$dat$ID1, df1$dat$ID1, useNA = "if", dnn = c("GADSdat", "other_GADSdat")))
 })

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -14,52 +14,59 @@ test_that("Errors",{
 
 test_that("Compare two identical GADSdat objects",{
   out <- inspectMetaDifferences(df1, varName = "V1")
-  expect_null(out$varDiff)
-  expect_null(out$valDiff)
+  expect_equal(out$varDiff, "all.equal")
+  expect_equal(out$valDiff, "all.equal")
 
   out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df2, other_varName = "ID1")
-  expect_null(out$varDiff)
-  expect_null(out$valDiff)
+  expect_equal(out$varDiff, "all.equal")
+  expect_equal(out$valDiff, "all.equal")
 
   out2 <- inspectMetaDifferences("helper_dataBase.db", varName = "V1")
-  expect_null(out2$varDiff)
-  expect_null(out2$valDiff)
+  expect_equal(out2$varDiff, "all.equal")
+  expect_equal(out2$valDiff, "all.equal")
 })
 
 test_that("Differences on variable level",{
   df1_2 <- changeVarLabels(df1, "V1", "some label")
   out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df1_2)
   expect_equal(names(out), c("varDiff", "valDiff"))
-  expect_equal(dim(out$varDiff), c(1, 5))
-  expect_equal(out$varDiff[1, 2], NA_character_)
-  expect_equal(out$varDiff[1, 4], "some label")
-  expect_null(out$valDiff)
+  expect_equal(names(out$varDiff), c("GADSdat_varLabel", "other_GADSdat_varLabel"))
+  expect_equal(as.character(out$varDiff[1, ]), c(NA, "some label"))
+  expect_equal(out$valDiff, "all.equal")
+
+  out2 <- inspectMetaDifferences(df1_2, varName = "ID1", other_varName = "V1")
+  expect_equal(names(out2$varDiff), c("ID1_varLabel", "V1_varLabel"))
+  expect_equal(as.character(out2$varDiff[1, ]), c(NA, "some label"))
 })
 
 
 test_that("Differences on value level",{
   df1_2 <- changeValLabels(df1, "V1", value = c(1, 3), valLabel = c("test 1", "test 2"))
   out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df1_2)
-
-  expect_equal(dim(out$valDiff), c(2, 6))
+  expect_equal(dim(out$valDiff), c(2, 5))
   expect_equal(out$valDiff[, "value"], c(1, 3))
-  expect_equal(out$valDiff[, "GADS1.valLabel"], c(NA_character_, NA))
-  expect_equal(out$valDiff[, "GADS2.valLabel"], c("test 1", "test 2"))
+  expect_equal(names(out$valDiff),
+               c("value", "GADSdat_valLabel", "GADSdat_missings", "other_GADSdat_valLabel", "other_GADSdat_missings"))
+  expect_equal(out$valDiff[, "GADSdat_valLabel"], c(NA_character_, NA))
+  expect_equal(out$valDiff[, "other_GADSdat_valLabel"], c("test 1", "test 2"))
 
   df1_3 <- changeValLabels(df1, "V1", value = c(1, 3), valLabel = c("test 1", "test 2b"))
   out2 <- inspectMetaDifferences(df1_2, varName = "V1", other_GADSdat = df1_3)
-
-  expect_equal(dim(out2$valDiff), c(1, 6))
   expect_equal(out2$valDiff[, "value"], 3)
-  expect_equal(out2$valDiff[, "GADS1.valLabel"], c("test 2"))
-  expect_equal(out2$valDiff[, "GADS2.valLabel"], c("test 2b"))
+  expect_equal(out2$valDiff[, "GADSdat_valLabel"], c("test 2"))
+  expect_equal(out2$valDiff[, "other_GADSdat_valLabel"], c("test 2b"))
+
+  out2b <- inspectMetaDifferences(df1_3, varName = "V1", other_varName = "ID1")
+  expect_equal(out2b$valDiff[, "value"], c(1, 3))
+  expect_equal(names(out2b$valDiff),
+               c("value", "V1_valLabel", "V1_missings", "ID1_valLabel", "ID1_missings"))
+
 
   df1_4 <- changeMissings(df1_3, "V1", value = c(1), missings = "miss")
   out3 <- inspectMetaDifferences(df1_4, varName = "V1", other_GADSdat = df1_3)
-
   expect_equal(out3$valDiff[, "value"], 1)
-  expect_equal(out3$valDiff[, "GADS1.missings"], c("miss"))
-  expect_equal(out3$valDiff[, "GADS2.missings"], c("valid"))
+  expect_equal(out3$valDiff[, "GADSdat_missings"], c("miss"))
+  expect_equal(out3$valDiff[, "other_GADSdat_missings"], c("valid"))
 })
 
 test_that("Differences after recoding",{
@@ -67,8 +74,8 @@ test_that("Differences after recoding",{
   pisa2 <- recodeGADS(pisa2, varName = "sameteach", oldValues = c(1, 2), newValues = c(0, 1))
   out <- inspectMetaDifferences(pisa, varName = "sameteach", other_GADSdat = pisa2)
 
-  expect_equal(dim(out$valDiff), c(3, 6))
+  expect_equal(dim(out$valDiff), c(3, 5))
   expect_equal(out$valDiff[, "value"], 0:2)
-  expect_equal(out$valDiff[, "GADS1.valLabel"], c(NA, "No", "Yes"))
-  expect_equal(out$valDiff[, "GADS2.valLabel"], c("No", "Yes", NA))
+  expect_equal(out$valDiff[, "GADSdat_valLabel"], c(NA, "No", "Yes"))
+  expect_equal(out$valDiff[, "other_GADSdat_valLabel"], c("No", "Yes", NA))
 })

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -17,6 +17,10 @@ test_that("Compare two identical GADSdat objects",{
   expect_null(out$varDiff)
   expect_null(out$valDiff)
 
+  out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df2, other_varName = "ID1")
+  expect_null(out$varDiff)
+  expect_null(out$valDiff)
+
   out2 <- inspectMetaDifferences("helper_dataBase.db", varName = "V1")
   expect_null(out2$varDiff)
   expect_null(out2$valDiff)

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -4,26 +4,27 @@ load(file = "helper_data.rda")
 
 test_that("Errors",{
   df1_5 <- df1_4 <- df1_2 <- df1_3 <- df1
-  expect_error(inspectMetaDifferences(c("1", "2"), df1, df1_2),
+  expect_error(inspectMetaDifferences(df1, varName = c("1", "2"), other_GADSdat = df1_2),
                "'varName' needs to be a character vector of length 1.")
-  expect_error(inspectMetaDifferences("v1", df1, df1_2),
-               "The following 'varName' are not variables in the GADSdat1: v1")
+  expect_error(inspectMetaDifferences(df1, varName = "v1", other_GADSdat = df1_2),
+               "The following 'varName' are not variables in the GADSdat: v1")
+  expect_error(inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df2),
+               "The following 'other_varName' are not variables in the other_GADSdat: V1")
 })
 
 test_that("Compare two identical GADSdat objects",{
-  out <- inspectMetaDifferences("V1", df1, df1)
+  out <- inspectMetaDifferences(df1, varName = "V1")
   expect_null(out$varDiff)
   expect_null(out$valDiff)
 
-  out2 <- inspectMetaDifferences("V1", "helper_dataBase.db",
-                                "helper_dataBase.db")
+  out2 <- inspectMetaDifferences("helper_dataBase.db", varName = "V1")
   expect_null(out2$varDiff)
   expect_null(out2$valDiff)
 })
 
 test_that("Differences on variable level",{
   df1_2 <- changeVarLabels(df1, "V1", "some label")
-  out <- inspectMetaDifferences("V1", df1, df1_2)
+  out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df1_2)
   expect_equal(names(out), c("varDiff", "valDiff"))
   expect_equal(dim(out$varDiff), c(1, 5))
   expect_equal(out$varDiff[1, 2], NA_character_)
@@ -34,7 +35,7 @@ test_that("Differences on variable level",{
 
 test_that("Differences on value level",{
   df1_2 <- changeValLabels(df1, "V1", value = c(1, 3), valLabel = c("test 1", "test 2"))
-  out <- inspectMetaDifferences("V1", df1, df1_2)
+  out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df1_2)
 
   expect_equal(dim(out$valDiff), c(2, 6))
   expect_equal(out$valDiff[, "value"], c(1, 3))
@@ -42,7 +43,7 @@ test_that("Differences on value level",{
   expect_equal(out$valDiff[, "GADS2.valLabel"], c("test 1", "test 2"))
 
   df1_3 <- changeValLabels(df1, "V1", value = c(1, 3), valLabel = c("test 1", "test 2b"))
-  out2 <- inspectMetaDifferences("V1", df1_2, df1_3)
+  out2 <- inspectMetaDifferences(df1_2, varName = "V1", other_GADSdat = df1_3)
 
   expect_equal(dim(out2$valDiff), c(1, 6))
   expect_equal(out2$valDiff[, "value"], 3)
@@ -50,7 +51,7 @@ test_that("Differences on value level",{
   expect_equal(out2$valDiff[, "GADS2.valLabel"], c("test 2b"))
 
   df1_4 <- changeMissings(df1_3, "V1", value = c(1), missings = "miss")
-  out3 <- inspectMetaDifferences("V1", df1_4, df1_3)
+  out3 <- inspectMetaDifferences(df1_4, varName = "V1", other_GADSdat = df1_3)
 
   expect_equal(out3$valDiff[, "value"], 1)
   expect_equal(out3$valDiff[, "GADS1.missings"], c("miss"))
@@ -60,7 +61,7 @@ test_that("Differences on value level",{
 test_that("Differences after recoding",{
   pisa2 <- changeVarLabels(pisa, varName = "sameteach", varLabel = "Same math teacher")
   pisa2 <- recodeGADS(pisa2, varName = "sameteach", oldValues = c(1, 2), newValues = c(0, 1))
-  out <- inspectMetaDifferences("sameteach", pisa, pisa2)
+  out <- inspectMetaDifferences(pisa, varName = "sameteach", other_GADSdat = pisa2)
 
   expect_equal(dim(out$valDiff), c(3, 6))
   expect_equal(out$valDiff[, "value"], 0:2)


### PR DESCRIPTION
Currently, data and meta differences can only be inspected between two different `GADSdat` objects. This PR allows to perform such comparisons on two variables within a single `GADSdat`. The argument framework is borrowed from the implementation of `resueMeta()`.

The PR is also used to tidy up input validation of both functions.