### PR TITLE
fix applyLookup for multiple variables with NAs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * `inspectDifferences()` and `inspectMetaDifferences()` now allow comparisons of variables within the same `GADSdat` object (#62)
 
 ## bug fixes
+* `applyLookup()` now works for multiple variables that contain `NAs` (#68)
 * `applyChangeMeta()` and `recodeGADS()` now correctly perform recodings (and throw errors) if multiple meta data conflicts occur (#57)
 * `removeEmptyValLabels()` for removing unused missing tags and value labels (#4)
 * `extractData()` and `extractData2()` now correctly apply value labels, even when value and value label conflicts exist

--- a/R/applyLookup.R
+++ b/R/applyLookup.R
@@ -72,9 +72,17 @@ applyLookup.GADSdat <- function(GADSdat, lookup, suffix = NULL) {
     }
 
     suppressWarnings(test <- compare_and_order(rec_df[[nam]], set2 = sub_lu[[nam]]))
-    if(length(test$not_in_set1) != 0) warning("For variable ", nam, " the following values are in the lookup table but not in the data: ", paste(test$not_in_set1, collapse = ", "))
-    if(length(test$not_in_set2) != 0) warning("For variable ", nam, " the following values are in the data but not in the lookup table: ", paste(test$not_in_set2, collapse = ", "))
-    if(length(test$not_in_set2) != 0 && "" %in% test$not_in_set2) warning("Empty strings are values in the data but not in the look up table. Using recodeString2NA() is recommended.")
+    if(length(test$not_in_set1) != 0) {
+      warning("For variable ", nam, " the following values are in the lookup table but not in the data: ",
+              paste(test$not_in_set1, collapse = ", "))
+    }
+    if(length(test$not_in_set2) != 0) {
+      warning("For variable ", nam, " the following values are in the data but not in the lookup table: ",
+              paste(test$not_in_set2, collapse = ", "))
+    }
+    if(length(test$not_in_set2) != 0 && "" %in% test$not_in_set2) {
+      warning("Empty strings are values in the data but not in the look up table. Using recodeString2NA() is recommended.")
+    }
 
     old_nam <- nam
     if(!is.null(suffix)) {
@@ -101,9 +109,25 @@ applyLookup.GADSdat <- function(GADSdat, lookup, suffix = NULL) {
 
 
 check_lookup <- function(lookup, GADSdat) {
-  if(!all(lookup$variable %in% namesGADS(GADSdat))) stop("Some of the variables are not variables in the GADSdat.")
-  if(!identical(names(lookup), c("variable", "value", "value_new"))) stop("'lookup' table has to be formatted correctly.")
-  if(sum(is.na(lookup$value)) > 1) stop("In more than 1 row value is missing.")
-  if(all(is.na(lookup$value_new))) stop("No values have a recode value assigned (missings in value_new).")
-  if(any(is.na(lookup$value_new))) warning("Not all values have a recode value assigned (missings in value_new).")
+  if(!all(lookup$variable %in% namesGADS(GADSdat))) {
+    stop("Some of the variables are not variables in the GADSdat.")
+  }
+  if(!identical(names(lookup), c("variable", "value", "value_new"))) {
+    stop("'lookup' table has to be formatted correctly.")
+  }
+  if(all(is.na(lookup$value_new))) {
+    stop("No values have a recode value assigned (missings in value_new).")
+  }
+  by(lookup, lookup$variable, function(sub_lookup) {
+    dup_values <- sub_lookup$value[duplicated(sub_lookup$value)]
+    if(length(dup_values) > 0) {
+      varName <- sub_lookup[1, "variable"]
+      stop("There are duplicate values in the lookup for variable '", varName,"': ",
+           paste(dup_values, collapse = ", "))
+    }
+  })
+  if(any(is.na(lookup$value_new))) {
+    warning("Not all values have a recode value assigned (missings in value_new).")
+  }
+  NULL
 }

--- a/tests/testthat/test_applyLookup.R
+++ b/tests/testthat/test_applyLookup.R
@@ -8,20 +8,24 @@ lu2 <- createLookup(testM, recodeVars = c("VAR1"), sort_by = "value")
 lu3 <- createLookup(testM, recodeVars = c("VAR1", "VAR2"), sort_by = "value")
 
 test_that("Check Lookup, errors and warnings",{
-  expect_error(check_lookup(lu2, testM), "No values have a recode value assigned (missings in value_new).", fixed = TRUE)
+  expect_error(check_lookup(lu2, testM),
+               "No values have a recode value assigned (missings in value_new).", fixed = TRUE)
 
   lu2_3 <- lu2_2 <- lu2_1 <- lu2
   lu2_1[1, 1] <- "v10"
-  expect_error(check_lookup(lu2_1, testM), "Some of the variables are not variables in the GADSdat.")
+  expect_error(check_lookup(lu2_1, testM),
+               "Some of the variables are not variables in the GADSdat.")
   lu2_2[1, 2] <- NA
   lu2_2[1, 3] <- 1
   expect_silent(suppressWarnings(check_lookup(lu2_2, testM)))
   lu2_2[2, 2] <- NA
-  expect_error(check_lookup(lu2_2, testM), "In more than 1 row value is missing.")
+  expect_error(check_lookup(lu2_2, testM),
+               "There are duplicate values in the lookup for variable 'VAR1': NA")
 
   lu2_3[1, 3] <- -9
   w <- capture_warnings(applyLookup(testM, lu2_3, suffix = "_r"))
-  expect_equal(w[1], "Not all values have a recode value assigned (missings in value_new).")
+  expect_equal(w[1],
+               "Not all values have a recode value assigned (missings in value_new).")
 })
 
 test_that("Warnings for incomplete lookup/lookup with additional values",{
@@ -143,7 +147,6 @@ test_that("Workflow multiple columns, collapse, apply",{
   expect_equal(testM2$dat$VAR1_r, c(1, -2, 3, 4))
 })
 
-
 test_that("Specific warning for empty strings (necessary due to readxl)",{
   df <- data.frame(v1 = c(1, 1, 2), v2 = c("lala", "", ""), stringsAsFactors = FALSE)
   gads <-import_DF(df)
@@ -153,4 +156,15 @@ test_that("Specific warning for empty strings (necessary due to readxl)",{
   warns <- capture_warnings(applyLookup(gads, l, suffix = "_r"))
 
   expect_equal(warns[3], "Empty strings are values in the data but not in the look up table. Using recodeString2NA() is recommended.")
+})
+
+test_that("Applying recode for multiple variables with NAs",{
+  dat <- data.frame(v1 = c(1, NA), v2 = c(1, NA))
+  gads <- import_DF(dat)
+  lookup <- createLookup(gads, c("v1", "v2"))
+  lookup$value_new <- c(5, -99, 6, -99)
+  out <- applyLookup(gads, lookup, suffix = NULL)
+
+  expect_equal(out$dat$v1, c(5, -99))
+  expect_equal(out$dat$v2, c(6, -99))
 })

--- a/tests/testthat/test_applyLookup_expandVar.R
+++ b/tests/testthat/test_applyLookup_expandVar.R
@@ -16,10 +16,6 @@ test_that("Errors for apply lookup with expanding into multiple variables", {
   expect_error(applyLookup_expandVar(l_gads, lookup2),
                "'lookup' table has to be formatted correctly.")
 
-  lookup3$value[1:2] <- NA
-  expect_error(applyLookup_expandVar(l_gads, lookup3),
-               "In more than 1 row value is missing.")
-
   lookup4$new_value1[1] <- NA
   expect_warning(applyLookup_expandVar(l_gads, lookup4),
                  "Not all values have a recode value assigned (missings in value_new).", fixed = TRUE)


### PR DESCRIPTION
This PR adresses #68. `applyLookup()` currently throws an error if multiple variables are being recoded that contain `NAs`. This seems to be an artifact of a time when `applyLookup()` was only meant to work on a single variable.

This PR modifies `check_lookup()` to, instead of specifically checking for `NAs`, check the uniqueness of the `value` column (i.e., the values which are being recoded) in the lookup table for all possible values.

Note that this check should be rarely triggered, as such a incorrect lookup table will not be generated by `createLookup()`. However, the lookup table may be (unintentionally) be modified by the user before calling `applyLookup()`.