### PR TITLE
extractData2 fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * `extractData()` and `extractData2()` now correctly apply value labels, even when value and value label conflicts exist
 * `write_spss2()` now also handles variables containing only NA values when `format` is also NA (#72)
 * `changeMissings()` now correctly changes missing labels for values of variables with partially non-existent `value`s and/or `valLabel`s (#73)
+* `extractData2()` now correctly transforms variables with duplicate value labels (#77)
 
 # eatGADS 1.1.0
 

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -161,7 +161,8 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
       dup_valLabels <- single_change_labels[duplicated(single_change_labels$valLabel), "valLabel"]
       affected_values <- single_change_labels[single_change_labels$valLabel == dup_valLabels, ]
       for(dup_valLabel in dup_valLabels) {
-        warning("Duplicate value label in variable ", nam, ": ", dup_valLabel, ". Information may be lost when extracting data.")
+        warning("Duplicate value label in variable ", nam, ". The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
+                eatTools::print_and_capture(affected_values))
 
         # recode actual data to prevent any potential issues with char2fac later
         value_lookup <- data.frame(oldValues = affected_values[, "value"],

--- a/man/extractData2.Rd
+++ b/man/extractData2.Rd
@@ -51,6 +51,9 @@ If this is not possible, a warning is issued.
 As \code{SPSS} has almost no limitations regarding the underlying values of labeled
 integers and \code{R}'s \code{factor} format is very strict (no \code{0}, only integers increasing by \code{+ 1}),
 this procedure can lead to frequent problems.
+
+If multiple values of the same variable are assigned the same value label and the variable should be transformed to
+\code{character}, \code{factor}, or \code{ordered}, a warning is issued and the transformation is correctly performed.
 }
 \examples{
 # Extract Data for Analysis

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -54,7 +54,9 @@ test_that("Extract data into factor with duplicate value labels", {
   testM3$dat$VAR1 <- testM3$dat$VAR1
   outW <- capture_warnings(out <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE))
 
-  expect_equal(outW[2], "Duplicate value label in variable VAR1: One. Information may be lost when extracting data.")
+  expect_equal(outW[2],
+               paste0("Duplicate value label in variable VAR1. The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
+                      eatTools::print_and_capture(testM3$labels[testM3$labels$varName == "VAR1" & testM3$labels$valLabel == "One", ])))
   expect_equal(class(out$VAR1), "factor")
   out_factor <- factor(c("One", NA, NA, "One"))
   attr(out_factor, "label") <- "Variable 1"

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -1,8 +1,6 @@
 
-# load(file = "tests/testthat/helper_data.rda")
-# testM <- import_spss("tests/testthat/helper_spss_missings.sav")
-testM <- import_spss("helper_spss_missings.sav")
-load(file = "helper_data.rda")
+testM <- import_spss(test_path("helper_spss_missings.sav"))
+load(file = test_path("helper_data.rda"))
 
 control_caching <- FALSE
 
@@ -12,7 +10,7 @@ testM2 <- testM
 testM2$dat[, "Var_char"] <- c("a", "b", "c", "d")
 testM2$dat[, "Var_char2"] <- c(1, 1, 1, 1)
 testM2$labels[8, ] <- c("Var_char", NA, NA, NA, NA, NA, NA, NA)
-testM2$labels[9, ] <- c("Var_char2", NA, NA, NA, "labeled", 1, "b_value", NA)
+testM2$labels[9, ] <- c("Var_char2", NA, NA, NA, "yes", 1, "b_value", NA)
 testM2$labels$value <- as.numeric(testM2$labels$value)
 
 test_that("Warnings and errors for Extract Data",  {
@@ -49,6 +47,25 @@ test_that("Extract data for strings into factors", {
   expect_equal(class(out$Var_char), "character")
   expect_equal(class(out$Var_char2), "factor")
   expect_equal(out$Var_char2, as.factor(c("b_value", "b_value", "b_value", "b_value")))
+})
+
+test_that("Extract data into factor with duplicate value labels", {
+  testM3 <- changeValLabels(testM2, varName = "VAR1", value = "2", valLabel = "One")
+  testM3$dat$VAR1 <- testM3$dat$VAR1
+  outW <- capture_warnings(out <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE))
+
+  expect_equal(outW[2], "Duplicate value label in variable VAR1: One. Information may be lost when extracting data.")
+  expect_equal(class(out$VAR1), "factor")
+  out_factor <- factor(c("One", NA, NA, "One"))
+  attr(out_factor, "label") <- "Variable 1"
+  expect_equal(out$VAR1, out_factor)
+
+  suppressWarnings(out2 <- extractData2(testM3, labels2factor = "VAR1", convertMiss = FALSE))
+
+  expect_equal(class(out2$VAR1), "factor")
+  out_factor2 <- factor(c("One", "By design", "Omission", "One"))
+  attr(out_factor2, "label") <- "Variable 1"
+  expect_equal(out2$VAR1, out_factor2)
 })
 
 test_that("Extract data for strings into factors and ordered", {


### PR DESCRIPTION
This PR adresses the bug reported in #77. 

Note that this PR fixes the bug for `extractData2()`, not for `extractData()`. However, I suggest to make `extractData()` a wrapper of `extractData2()` (see #82), which would automatically fix this issue for `extractData()` as well.

One review within the next few days would be great ✌️ 