### PR TITLE
fix autoRecode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * `extractData()` and `extractData2()` now correctly apply value labels, even when value and value label conflicts exist
 * `write_spss2()` now also handles variables containing only NA values when `format` is also NA (#72)
 * `changeMissings()` now correctly changes missing labels for values of variables with partially non-existent `value`s and/or `valLabel`s (#73)
+* `autoRecode()` now correctly overwrites the existing variable if `var_suffix = ""` (#84)
 
 # eatGADS 1.1.0
 

--- a/R/autoRecode.R
+++ b/R/autoRecode.R
@@ -39,14 +39,18 @@ autoRecode.GADSdat <- function(GADSdat, var, var_suffix = "", label_suffix = "",
 
   # duplicate
   new_var <- paste0(var, var_suffix)
-  GADSdat_out <- cloneVariable(GADSdat = GADSdat, varName = var, new_varName = new_var, label_suffix = label_suffix)
+  if(!identical(new_var, var)) {
+    GADSdat_out <- cloneVariable(GADSdat = GADSdat, varName = var, new_varName = new_var, label_suffix = label_suffix)
+  } else {
+    GADSdat_out <- append_varLabel(GADSdat, varName = var, label_suffix = label_suffix)
+  }
 
   if(is.null(template)) {
-    # to character
+    # new variable to character
     GADSdat_out[["dat"]][[new_var]] <- as.character(GADSdat_out[["dat"]][[new_var]])
     GADSdat_out <- changeSPSSformat(GADSdat_out, varName = new_var, format = "A10")
 
-    # to factor
+    # new variable to factor
     GADSdat_out <- multiChar2fac(GADSdat_out, vars = new_var, var_suffix = "", label_suffix = "")
 
     # look up table
@@ -58,6 +62,7 @@ autoRecode.GADSdat <- function(GADSdat, var, var_suffix = "", label_suffix = "",
       stop()
     }
 
+    # recoding the actual data via a lookup table
     new_oldValues <- GADSdat$dat[[var]][!GADSdat$dat[[var]] %in% template$oldValue]
     new_newValues <- seq(from = max(template$newValue) + 1, length.out = length(new_oldValues))
     lookup <- rbind(template, data.frame(oldValue = new_oldValues, newValue = new_newValues))

--- a/R/cloneVariable.R
+++ b/R/cloneVariable.R
@@ -30,10 +30,12 @@ cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = 
   if(new_varName %in% namesGADS(GADSdat)) {
     stop("'",  new_varName, "' is already an existing variable in the 'GADSdat'.")
   }
+  ##<Note>
   ## alternativley, cloneVariable() could be extended to accept new_varName == varName. The only action
   ## performed would be to append label_suffix. This would allow using the function more straightforward
   ## in functions such as autoRecode(). As of now, only autoRecode() is using cloneVariable(), therefore
   ## such an extension is postponed.
+  ##</Note>
 
   dat_only <- GADSdat$dat
   dat_only[[new_varName]] <- dat_only[[varName]]

--- a/R/cloneVariable.R
+++ b/R/cloneVariable.R
@@ -30,6 +30,10 @@ cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = 
   if(new_varName %in% namesGADS(GADSdat)) {
     stop("'",  new_varName, "' is already an existing variable in the 'GADSdat'.")
   }
+  ## alternativley, cloneVariable() could be extended to accept new_varName == varName. The only action
+  ## performed would be to append label_suffix. This would allow using the function more straightforward
+  ## in functions such as autoRecode(). As of now, only autoRecode() is using cloneVariable(), therefore
+  ## such an extension is postponed.
 
   dat_only <- GADSdat$dat
   dat_only[[new_varName]] <- dat_only[[varName]]

--- a/tests/testthat/test_autoRecode.R
+++ b/tests/testthat/test_autoRecode.R
@@ -1,8 +1,6 @@
 # load test data (df1, df2, pkList, fkList)
-# load(file = "tests/testthat/helper_data.rda")
-load(file = "helper_data.rda")
-# dfSAV <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
-dfSAV <- import_spss(file = "helper_spss_missings.sav")
+load(file = test_path("helper_data.rda"))
+dfSAV <- import_spss(file = test_path("helper_spss_missings.sav"))
 
 df <- data.frame(id = c(110, 115, 112, 110), var1 = c(1, 1, 3, 1))
 g <- import_DF(df)

--- a/tests/testthat/test_autoRecode.R
+++ b/tests/testthat/test_autoRecode.R
@@ -14,6 +14,13 @@ test_that("auto recode a variable", {
   expect_equal(out$labels[3, 2], "(recoded)", fixed = TRUE)
 })
 
+test_that("auto recode a variable while overwriting it", {
+  out <- autoRecode(g, var = "id", var_suffix = "", label_suffix = "(recoded)")
+  expect_equal(namesGADS(out), c("id", "var1"))
+  expect_equal(out$dat$id, c(1, 3, 2, 1))
+  expect_equal(out$labels[1, 2], "(recoded)", fixed = TRUE)
+})
+
 
 test_that("save lookup", {
   f <- tempfile(fileext = ".csv")


### PR DESCRIPTION
This PR adresses #84. In the past, `autoRecode()` was not able to deal with `var_suffix = ""`, which ironically is the argument default value.
