### PR TITLE
refactor extractData and extractDataOld

### DIFF
--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -198,3 +198,64 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
   }
   dat2
 }
+
+# check if variable is correctly labeled, issues warning
+check_labels <- function(varName, dat, labels, convertMiss) {
+  # if(varName == "VAR3") browser()
+  real_values <- na_omit(unique(dat[[varName]]))
+  labeled_values <- na_omit(labels[labels$varName == varName, "value"])
+  ## either all labeled
+  if(all(real_values %in% labeled_values)) return()
+  ## or no labels except missings (if missings are recoded, else this is irrelevant)
+  if(identical(convertMiss, TRUE)) {
+    labeled_values <- na_omit(labels[labels$varName == varName & labels$missings == "valid", "value"])
+    if(length(labeled_values) == 0) return(varName)
+  }
+  warning("Variable ", varName, " is partially labeled. Value labels will be dropped for this variable.\n",
+          "Labeled values are: ", paste(labeled_values, collapse = ", "), call. = FALSE)
+
+  varName
+  #warning("Variable ", varName, " is partially labeled. Value labels will be dropped for this variable variable.\nExisting values are: ",
+  #        paste(real_values, collapse = ", "), "\n", "Labeled values are: ", paste(labeled_values_noMiss, collapse = ", "), call. = FALSE)
+}
+
+na_omit <- function(vec) {
+  vec[!is.na(vec)]
+}
+
+# convert characters to factor if specified (keep ordering if possible)
+char2fac <- function(dat, labels, vars, convertMiss, ordered = FALSE) {
+  partially_labeled <- unordered_facs <- vars
+  for(i in vars) {
+    fac_meta <- labels[labels$varName == i & (is.na(labels$missings) | labels$missings != "miss")  , c("value", "valLabel")]
+    ## additionalcolumns relevant, if missings are not converted
+    if(convertMiss == FALSE) fac_meta <- labels[labels$varName == i, c("value", "valLabel")]
+    fac_meta <- fac_meta[order(fac_meta$value), ]
+
+    ## 3 scenarios: a) ordering possible, b) ordering impossible because no strictly integers from 1 rising,
+    # c) Ordering impossible because partially labelled
+    if(nrow(fac_meta) < length(unique(dat[!is.na(dat[, i]), i]))) {
+      dat[, i] <- factor(dat[, i])
+      unordered_facs <- unordered_facs[unordered_facs != i]
+    } else{
+      partially_labeled <- partially_labeled[partially_labeled != i]
+      if(all(fac_meta$value == seq(nrow(fac_meta)))) unordered_facs <- unordered_facs[unordered_facs != i]
+
+      dat[, i] <- factor(dat[, i], levels = fac_meta$valLabel, ordered = ordered)
+    }
+  }
+
+  if(length(partially_labeled) > 0) warning("For the following factor variables only incomplete value labels are available, rendering the underlying integers meaningless: ",
+                                            paste(partially_labeled, collapse = ", "))
+  if(length(unordered_facs) > 0) warning("For the following factor variables the underlying integers can not be preserved due to R-incompatible ordering of numeric values: ",
+                                         paste(unordered_facs, collapse = ", "))
+  dat
+}
+
+varLabels_as_labels <- function(dat, labels) {
+  for(i in names(dat)) {
+    varLabel <- labels[match(i, labels$varName), "varLabel"]
+    if(!is.na(varLabel)) attr(dat[[i]], "label") <- varLabel
+  }
+  dat
+}

--- a/R/extractDataOld.R
+++ b/R/extractDataOld.R
@@ -23,17 +23,24 @@ extractDataOld <- function(GADSdat, convertMiss = TRUE, convertLabels = "charact
 
 #'@export
 extractDataOld.GADSdat <- function(GADSdat, convertMiss = TRUE, convertLabels = "character", dropPartialLabels = TRUE, convertVariables = NULL) {
-  stop("extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' objects. Please use extractData() for 'GADSdat' objects.")
+  stop("extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' objects. Please use extractData2() or extractData() for 'GADSdat' objects.")
 }
 
 #'@export
 extractDataOld.trend_GADSdat <- function(GADSdat, convertMiss = TRUE, convertLabels = "character", dropPartialLabels = TRUE, convertVariables = NULL) {
   names_no_LEs <- names(GADSdat$datList)[names(GADSdat$datList) != "LEs"]
-  if(length(names_no_LEs) > 2) stop("extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' with data from two data bases. For 'trend_GADSdat' objects with data from more than two data bases use extractData() instead.")
+  if(length(names_no_LEs) > 2) {
+    stop("extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' with data from two data bases. For 'trend_GADSdat' objects with data from more than two data bases use extractData2() or extractData() instead.")
+  }
   check_trend_GADSdat(GADSdat)
 
-  all_dat <- extract_data_only(GADSdat = GADSdat, convertMiss = convertMiss, convertLabels = convertLabels,
-                               dropPartialLabels = dropPartialLabels, convertVariables = convertVariables)
+  GADSdat_noLEs <- GADSdat
+  GADSdat_noLEs$datList <- GADSdat_noLEs$datList[names(GADSdat_noLEs$datList) != "LEs"]
+  class(GADSdat) <- class(GADSdat)
+
+  all_dat <-   transform_call_extractData2(GADSdat = GADSdat_noLEs, convertMiss = convertMiss,
+                                           convertLabels = convertLabels, dropPartialLabels = dropPartialLabels,
+                                           convertVariables = convertVariables)
 
   ## if available, merge also linking errors; merge picks by automatically, keep variable order as in original data frames
   if(!is.null(GADSdat$datList[["LEs"]])) {

--- a/tests/testthat/test_extractData.R
+++ b/tests/testthat/test_extractData.R
@@ -1,10 +1,7 @@
 
 # load data with missings
-# testM <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
-# load(file = "tests/testthat/helper_data.rda")
-# testM <- import_spss("tests/testthat/helper_spss_missings.sav")
-testM <- import_spss("helper_spss_missings.sav")
-load(file = "helper_data.rda")
+testM <- import_spss(test_path("helper_spss_missings.sav"))
+load(file = test_path("helper_data.rda"))
 
 control_caching <- FALSE
 
@@ -21,7 +18,7 @@ test_that("Warnings and errors for Extract Data",  {
   w <- capture_warnings(extractData(testM))
   expect_equal(w[[1]], "Variable VAR1 is partially labeled. Value labels will be dropped for this variable.\nLabeled values are: 1")
   expect_equal(w[[2]], "Variable VAR2 is partially labeled. Value labels will be dropped for this variable.\nLabeled values are: -96")
-  expect_error(extractData(testM, convertLabels = "integer"), "Argument convertLabels incorrectly specified.")
+  expect_error(extractData(testM, convertLabels = "integer"))
 })
 
 test_that("Extract data", {
@@ -186,8 +183,8 @@ test_that("ExtractData with some variables labels applied to (convertVariables a
 })
 
 test_that("Extract data trend GADS", {
-  # trend_gads <- getTrendGADS(filePaths = c("tests/testthat/helper_dataBase.db", "tests/testthat/helper_dataBase_uniqueVar.db"), years = c(2012, 2018), fast = FALSE)
-  trend_gads <- suppressWarnings(getTrendGADS(filePaths = c("helper_dataBase.db", "helper_dataBase_uniqueVar.db"),
+  trend_gads <- suppressWarnings(getTrendGADS(filePaths =
+                                                test_path(c("helper_dataBase.db", "helper_dataBase_uniqueVar.db")),
                                               years = c(2012, 2018), fast = FALSE, verbose = FALSE))
   out <- extractData(trend_gads)
   expect_equal(dim(out), c(6, 5))
@@ -198,6 +195,7 @@ test_that("Extract data trend GADS", {
 
   ## convertVariables if some variables are not in both GADS
   out2 <- extractData(trend_gads, convertVariables = "V3")
+  out2 <- extractData2(trend_gads, labels2character = "V3")
   expect_equal(out, out2)
 })
 
@@ -217,9 +215,11 @@ test_that("Extract data trend GADS 3 MPs", {
 
 ### with linking errors
 test_that("with linking errors present", {
-  # out <- getTrendGADSOld(filePath1 = "tests/testthat/helper_comp.db", filePath2 = "tests/testthat/helper_comp2.db", years = c(2012, 2018), lePath = "tests/testthat/helper_le.db", fast = FALSE, vSelect = c("ID", "PV"))
-  out <- getTrendGADSOld(filePath1 = "helper_comp.db", filePath2 = "helper_comp2.db", years = c(2012, 2018),
-                         lePath = "helper_le.db", fast = control_caching, vSelect = c("ID", "PV"))
+  out <- getTrendGADSOld(filePath1 = test_path("helper_comp.db"),
+                         filePath2 = test_path("helper_comp2.db"),
+                         years = c(2012, 2018),
+                         lePath = test_path("helper_le.db"),
+                         fast = control_caching, vSelect = c("ID", "PV"))
   expect_error(dat <- extractData(out),
                "Linking errors are no longer supported by extractData. Use extractDataOld() instead.", fixed = TRUE)
 })

--- a/tests/testthat/test_extractData.R
+++ b/tests/testthat/test_extractData.R
@@ -47,6 +47,30 @@ test_that("Extract data for strings into factors", {
   expect_equal(out$Var_char2, as.factor(c("b_value", "b_value", "b_value", "b_value")))
 })
 
+test_that("Extract data into factor with duplicate value labels", {
+  testM3 <- changeValLabels(testM2, varName = "VAR1", value = "2", valLabel = "One")
+  testM3$dat$VAR1 <- testM3$dat$VAR1
+  outW <- capture_warnings(out <- extractData(testM3, convertLabels = "factor",
+                                              convertVariables = "VAR1", convertMiss = TRUE))
+
+  expect_equal(outW[2],
+               paste0("Duplicate value label in variable VAR1. The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
+                      eatTools::print_and_capture(testM3$labels[testM3$labels$varName == "VAR1" & testM3$labels$valLabel == "One", ])))
+  expect_equal(class(out$VAR1), "factor")
+  out_factor <- factor(c("One", NA, NA, "One"))
+  attr(out_factor, "label") <- "Variable 1"
+  expect_equal(out$VAR1, out_factor)
+
+  suppressWarnings(out2 <- extractData(testM3, convertLabels = "factor",
+                                       convertVariables = "VAR1", convertMiss = FALSE))
+
+  expect_equal(class(out2$VAR1), "factor")
+  out_factor2 <- factor(c("One", "By design", "Omission", "One"))
+  attr(out_factor2, "label") <- "Variable 1"
+  expect_equal(out2$VAR1, out_factor2)
+})
+
+
 test_that("char2fac", {
   df <- data.frame(v1 = factor(c("z", "a", "b"), levels = c("z", "a", "b")),
                    stringsAsFactors = TRUE)

--- a/tests/testthat/test_extractDataOld.R
+++ b/tests/testthat/test_extractDataOld.R
@@ -1,28 +1,27 @@
 
-# load(file = "tests/testthat/helper_data.rda")
-# testM <- import_spss("tests/testthat/helper_spss_missings.sav")
-testM <- import_spss("helper_spss_missings.sav")
-load(file = "helper_data.rda")
+testM <- import_spss(test_path("helper_spss_missings.sav"))
+load(file = test_path("helper_data.rda"))
 
 control_caching <- FALSE
 
 
 test_that("Warnings and errors",  {
   expect_error(extractDataOld(testM),
-               "extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' objects. Please use extractData() for 'GADSdat' objects.", fixed = TRUE)
+               "extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' objects. Please use extractData2() or extractData() for 'GADSdat' objects.", fixed = TRUE)
 
   fp1 <- system.file("extdata", "trend_gads_2020.db", package = "eatGADS")
   fp2 <- system.file("extdata", "trend_gads_2015.db", package = "eatGADS")
   fp3 <- system.file("extdata", "trend_gads_2010.db", package = "eatGADS")
   s <- capture_output(gads_3mp <- getTrendGADS(filePaths = c(fp1, fp2, fp3), years = c(2020, 2015, 2010), fast = FALSE))
   expect_error(extractDataOld(gads_3mp),
-               "extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' with data from two data bases. For 'trend_GADSdat' objects with data from more than two data bases use extractData() instead.", fixed = TRUE)
+               "extractDataOld() is only implemented for backwards compatability of 'trend_GADSdat' with data from two data bases. For 'trend_GADSdat' objects with data from more than two data bases use extractData2() or extractData() instead.", fixed = TRUE)
 })
 
 
 test_that("Extract data trend GADS", {
-  # trend_gads <- getTrendGADS(filePath1 = "tests/testthat/helper_dataBase.db", filePath2 = "tests/testthat/helper_dataBase_uniqueVar.db", years = c(2012, 2018), fast = FALSE)
-  trend_gads <- suppressWarnings(getTrendGADSOld(filePath1 = "helper_dataBase.db", filePath2 = "helper_dataBase_uniqueVar.db", years = c(2012, 2018), fast = FALSE))
+  trend_gads <- suppressWarnings(getTrendGADSOld(filePath1 = test_path("helper_dataBase.db"),
+                                                 filePath2 = test_path("helper_dataBase_uniqueVar.db"),
+                                                 years = c(2012, 2018), fast = FALSE))
   out <- extractDataOld(trend_gads)
   expect_equal(dim(out), c(6, 5))
   expect_equal(names(out), c("ID1", "V1", "V2", "V3", "year"))
@@ -36,8 +35,10 @@ test_that("Extract data trend GADS", {
 
 ### with linking errors
 test_that("With linking errors", {
-  # out <- getTrendGADS(filePath1 = "tests/testthat/helper_comp.db", filePath2 = "tests/testthat/helper_comp2.db", years = c(2012, 2018), lePath = "tests/testthat/helper_le.db", fast = FALSE, vSelect = c("ID", "level", "PV"))
-  out <- getTrendGADSOld(filePath1 = "helper_comp.db", filePath2 = "helper_comp2.db", years = c(2012, 2018), lePath = "helper_le.db", fast = control_caching, vSelect = c("ID", "PV"))
+  out <- getTrendGADSOld(filePath1 = test_path("helper_comp.db"),
+                         filePath2 = test_path("helper_comp2.db"),
+                         years = c(2012, 2018), lePath = test_path("helper_le.db"),
+                         fast = control_caching, vSelect = c("ID", "PV"))
   dat <- extractDataOld(out)
   expect_equal(dim(dat), c(8, 5))
   expect_equal(dat$LE_PV, c(rep(0.3, 4), rep(0.2, 4)))


### PR DESCRIPTION
This PR adresses #82 and indirectly #77.

It mainly refactors the `extractData()` and `extractDataOld()` code and transfers some helper functions from `extractData.R` to `extractData2.R`. 

One review is sufficient.