### PR TITLE
fix incorrect column names inspectMetaDifferences output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * `changeMissings()` now correctly changes missing labels for values of variables with partially non-existent `value`s and/or `valLabel`s (#73)
 * `autoRecode()` now correctly overwrites the existing variable if `var_suffix = ""` (#84)
 * `extractData2()` now correctly transforms variables with duplicate value labels (#77)
+* The output of `inspectMetaDifferences()` is no correctly named even if differences in variable labels and `SPSS` format occur (#81)
 
 # eatGADS 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
 * `changeMissings()` now correctly changes missing labels for values of variables with partially non-existent `value`s and/or `valLabel`s (#73)
 * `autoRecode()` now correctly overwrites the existing variable if `var_suffix = ""` (#84)
 * `extractData2()` now correctly transforms variables with duplicate value labels (#77)
-* The output of `inspectMetaDifferences()` is no correctly named even if differences in variable labels and `SPSS` format occur (#81)
+* The output of `inspectMetaDifferences()` is now correctly named even if differences in variable labels and `SPSS` format occur (#81)
 
 # eatGADS 1.1.0
 

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -60,7 +60,7 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
       names(varDiff) <- paste(nam_col, "varLabel", sep = "_")
       if(!identical(metaVar1$format, metaVar2$format)) {
         varDiff2 <- data.frame(metaVar1$format, metaVar2$format)
-        names(varDiff) <- paste(nam_col, "format", sep = "_")
+        names(varDiff2) <- paste(nam_col, "format", sep = "_")
 
         varDiff <- cbind(varDiff, varDiff2)[, c(1, 3, 2, 4)]
       }

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -1,6 +1,5 @@
 # load test data (df1, df2, pkList, fkList)
-# load(file = "tests/testthat/helper_data.rda")
-load(file = "helper_data.rda")
+load(file = test_path("helper_data.rda"))
 
 test_that("Errors",{
   df1_5 <- df1_4 <- df1_2 <- df1_3 <- df1
@@ -78,4 +77,12 @@ test_that("Differences after recoding",{
   expect_equal(out$valDiff[, "value"], 0:2)
   expect_equal(out$valDiff[, "GADSdat_valLabel"], c(NA, "No", "Yes"))
   expect_equal(out$valDiff[, "other_GADSdat_valLabel"], c("No", "Yes", NA))
+})
+
+test_that("Multiple differences",{
+  df1_2 <- changeSPSSformat(df1, "V1", "F4")
+  df1_2 <- changeVarLabels(df1_2, "V1", "some label")
+  out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df1_2)
+  expect_equal(names(out$varDiff),
+               c("GADSdat_varLabel", "GADSdat_format", "other_GADSdat_varLabel", "other_GADSdat_format"))
 })


### PR DESCRIPTION
This small PR fixes #81.

The column names in the `inspectMetaDifferences()` output are now correct even when both differences in variable labels and SPSS format occur.