### PR TITLE
fix extractData2 issue with duplicate NAs in valLabels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eatGADS
 Title: Data Management of Large Hierarchical Data
-Version: 1.1.1
+Version: 1.1.1.9000
 Authors@R: c(
     person("Benjamin", "Becker", email = "b.becker@iqb.hu-berlin.de", role = c("aut", "cre")),
     person("Karoline", "Sachse", role = c("ctb")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # eatGADS 1.1.1.9000
 ## bug fixes
 * `extractData2()` and `extractData()` no longer throw an error if multiple values of the same variable are labelled `NA` (#96)
+* `extractData2()` and `extractData()` no longer produce an error if there are multiple duplicate value labels in a variable 
 
 # eatGADS 1.1.1
 ## new features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# eatGADS 1.1.1.9000
+## bug fixes
+* `extractData2()` and `extractData()` no longer throw an error if multiple values of the same variable are labelled `NA` (#96)
+
 # eatGADS 1.1.1
 ## new features
 * `inspectDifferences()` and `inspectMetaDifferences()` now allow comparisons of variables within the same `GADSdat` object (#62)

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -154,26 +154,30 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
   if(nrow(change_labels) == 0) return(dat)
 
   # check for duplicate value labels (unfortunately possible in SPSS)
-  vars_with_duplicate_valLabels <- change_labels[duplicated(change_labels[, c("varName", "valLabel")]), "varName"]
+  vars_with_duplicate_valLabels <- unique(change_labels[duplicated(change_labels[, c("varName", "valLabel")]), "varName"])
   if(length(vars_with_duplicate_valLabels) > 0) {
-    for(nam in unique(vars_with_duplicate_valLabels)) {
+    for(nam in vars_with_duplicate_valLabels) {
       single_change_labels <- change_labels[change_labels$varName == nam, ]
       dup_valLabels <- single_change_labels[duplicated(single_change_labels$valLabel), "valLabel"]
       # exclude NAs. If valLables are NA, no label is applied anyway
       dup_valLabels <- dup_valLabels[!is.na(dup_valLabels)]
-      affected_values <- single_change_labels[single_change_labels$valLabel == dup_valLabels, ]
+      affected_values <- single_change_labels[single_change_labels$valLabel %in% dup_valLabels, ]
+
+      warning("Duplicate value label in variable ", nam
+              , ". The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
+              eatTools::print_and_capture(affected_values))
+
       for(dup_valLabel in dup_valLabels) {
-        warning("Duplicate value label in variable ", nam, ". The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
-                eatTools::print_and_capture(affected_values))
+        single_affected_values <- affected_values[affected_values$valLabel == dup_valLabel, ]
 
         # recode actual data to prevent any potential issues with char2fac later
-        value_lookup <- data.frame(oldValues = affected_values[, "value"],
-                                   newValues = affected_values[1, "value"])
+        value_lookup <- data.frame(oldValues = single_affected_values[, "value"],
+                                   newValues = single_affected_values[1, "value"])
         dat[, nam] <- eatTools::recodeLookup(dat[, nam], value_lookup)
 
         # remove superfluous meta data
         change_labels <- change_labels[!(change_labels$varName == nam &
-                                           change_labels$value %in% affected_values[-(1), "value"]), ]
+                                           change_labels$value %in% single_affected_values[-(1), "value"]), ]
   }}}
 
 

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -159,6 +159,8 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
     for(nam in unique(vars_with_duplicate_valLabels)) {
       single_change_labels <- change_labels[change_labels$varName == nam, ]
       dup_valLabels <- single_change_labels[duplicated(single_change_labels$valLabel), "valLabel"]
+      # exclude NAs. If valLables are NA, no label is applied anyway
+      dup_valLabels <- dup_valLabels[!is.na(dup_valLabels)]
       affected_values <- single_change_labels[single_change_labels$valLabel == dup_valLabels, ]
       for(dup_valLabel in dup_valLabels) {
         warning("Duplicate value label in variable ", nam, ". The following values (see value column) will be recoded into the same value label (see valLabel column):\n",

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -146,7 +146,7 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
   change_labels <- labels[labels[, "varName"] %in% convertVariables, ]    # careful, from here use only change_labels!
   # check value labels, remove incomplete labels from insertion to protect variables
   if(identical(dropPartialLabels, TRUE)) {
-    drop_labels <- unlist(lapply(unique(labels$varName), FUN = check_labels, dat = dat, labels = labels,
+    drop_labels <- unlist(lapply(unique(change_labels$varName), FUN = check_labels, dat = dat, labels = labels,
                                  convertMiss = convertMiss))
     change_labels <- change_labels[!change_labels$varName %in% drop_labels, ]
   }

--- a/tests/testthat/test_extractData.R
+++ b/tests/testthat/test_extractData.R
@@ -53,7 +53,7 @@ test_that("Extract data into factor with duplicate value labels", {
   outW <- capture_warnings(out <- extractData(testM3, convertLabels = "factor",
                                               convertVariables = "VAR1", convertMiss = TRUE))
 
-  expect_equal(outW[2],
+  expect_equal(outW,
                paste0("Duplicate value label in variable VAR1. The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
                       eatTools::print_and_capture(testM3$labels[testM3$labels$varName == "VAR1" & testM3$labels$valLabel == "One", ])))
   expect_equal(class(out$VAR1), "factor")

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -70,6 +70,19 @@ test_that("Extract data into factor with duplicate value labels", {
   expect_equal(out2$VAR1, out_factor2)
 })
 
+test_that("Extract data into factor with multiple value labels being NA", {
+  testM3 <- changeValLabels(testM2, varName = "VAR1", value = 2, valLabel = NA)
+  testM3$labels$valLabel[3] <- NA
+
+  suppressWarnings(out <- extractData2(testM3, labels2character = "VAR1", convertMiss = TRUE))
+  expect_equal(as.character(out$VAR1), c(1, NA_character_, NA, 2))
+
+  suppressWarnings(outF <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE))
+  empty_fac <- as.factor(rep(NA, 4))
+  attr(empty_fac, "label") <- "Variable 1"
+  expect_equal(outF$VAR1, empty_fac)
+})
+
 test_that("Extract data for strings into factors and ordered", {
   testM3 <- cloneVariable(testM2, varName = "Var_char2", new_varName = "Var_char3")
 

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -54,7 +54,7 @@ test_that("Extract data into factor with duplicate value labels", {
   testM3$dat$VAR1 <- testM3$dat$VAR1
   outW <- capture_warnings(out <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE))
 
-  expect_equal(outW[2],
+  expect_equal(outW,
                paste0("Duplicate value label in variable VAR1. The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
                       eatTools::print_and_capture(testM3$labels[testM3$labels$varName == "VAR1" & testM3$labels$valLabel == "One", ])))
   expect_equal(class(out$VAR1), "factor")

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -4,8 +4,6 @@ load(file = test_path("helper_data.rda"))
 
 control_caching <- FALSE
 
-
-######## extractData2
 testM2 <- testM
 testM2$dat[, "Var_char"] <- c("a", "b", "c", "d")
 testM2$dat[, "Var_char2"] <- c(1, 1, 1, 1)
@@ -51,12 +49,12 @@ test_that("Extract data for strings into factors", {
 
 test_that("Extract data into factor with duplicate value labels", {
   testM3 <- changeValLabels(testM2, varName = "VAR1", value = "2", valLabel = "One")
-  testM3$dat$VAR1 <- testM3$dat$VAR1
+  testM3 <- changeValLabels(testM3, varName = "VAR1", value = "-99", valLabel = "Omission")
   outW <- capture_warnings(out <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE))
 
-  expect_equal(outW,
+  expect_equal(outW[1],
                paste0("Duplicate value label in variable VAR1. The following values (see value column) will be recoded into the same value label (see valLabel column):\n",
-                      eatTools::print_and_capture(testM3$labels[testM3$labels$varName == "VAR1" & testM3$labels$valLabel == "One", ])))
+                      eatTools::print_and_capture(testM3$labels[testM3$labels$varName == "VAR1", ])))
   expect_equal(class(out$VAR1), "factor")
   out_factor <- factor(c("One", NA, NA, "One"))
   attr(out_factor, "label") <- "Variable 1"
@@ -65,7 +63,7 @@ test_that("Extract data into factor with duplicate value labels", {
   suppressWarnings(out2 <- extractData2(testM3, labels2factor = "VAR1", convertMiss = FALSE))
 
   expect_equal(class(out2$VAR1), "factor")
-  out_factor2 <- factor(c("One", "By design", "Omission", "One"))
+  out_factor2 <- factor(c("One", "Omission", "Omission", "One"))
   attr(out_factor2, "label") <- "Variable 1"
   expect_equal(out2$VAR1, out_factor2)
 })

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -74,6 +74,7 @@ test_that("Extract data into factor with multiple value labels being NA", {
   testM3 <- changeValLabels(testM2, varName = "VAR1", value = 2, valLabel = NA)
   testM3$labels$valLabel[3] <- NA
 
+  # values tagges as missing converted to NA and both valid values have NA as value label
   suppressWarnings(out <- extractData2(testM3, labels2character = "VAR1", convertMiss = TRUE))
   expect_equal(as.character(out$VAR1), c(1, NA_character_, NA, 2))
 


### PR DESCRIPTION
This PR addresses #96. Allowing duplicate value labels in `extractData2()` and `extractData()` introduced an issue if multiple values had `NA` as value label (which are technically also duplicate value labels).

This bug caused an issue in the `eatCodebook` full workflow vignette. 