### PR TITLE
Bugfix/98 extract data2 duplicate val labels on missings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 ## bug fixes
 * `extractData2()` and `extractData()` no longer throw an error if multiple values of the same variable are labelled `NA` (#96)
 * `extractData2()` and `extractData()` no longer produce an error if there are multiple duplicate value labels in a variable 
+* `extractData2()` and `extractData()` no longer produce a warning if multiple duplicate value labels occur which are tagged
+and transformed to `NA` anyway (#98)
+* `extractData2()` and `extractData()` now provide consistent output for values which have `NA` as value label (#99)
 
 # eatGADS 1.1.1
 ## new features

--- a/R/applyChangeMeta.R
+++ b/R/applyChangeMeta.R
@@ -145,8 +145,12 @@ check_changeTable <- function(GADSdat, changeTable) {
   return()
 }
 
-recode_dat <- function(dat, changeTable) {
-  value_df <- changeTable[!is.na(changeTable$value_new), c("varName", "value", "value_new")]
+recode_dat <- function(dat, changeTable, removeNAs = TRUE) {
+  value_df <- changeTable
+  if(removeNAs) {
+    value_df <- value_df[!is.na(value_df$value_new), c("varName", "value", "value_new")]
+  }
+
   for(nam in unique(value_df[, "varName"])) {
     single_value_df <- value_df[value_df[, "varName"] == nam, ]
     # initialize new vector

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -150,6 +150,11 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
                                  convertMiss = convertMiss))
     change_labels <- change_labels[!change_labels$varName %in% drop_labels, ]
   }
+  # if values tagged as missing are converted to NA anyway, there is no need to recode them
+  if(identical(convertMiss, TRUE)) {
+    change_labels <- change_labels[is.na(change_labels$missings) | change_labels$missings == "valid", ]
+  }
+
   # early return, if no values are to be recoded
   if(nrow(change_labels) == 0) return(dat)
 

--- a/R/extractData2.R
+++ b/R/extractData2.R
@@ -189,7 +189,7 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
   # convert labels into values (use recode function from applyChangeMeta)
   change_table <- change_labels[, c("varName", "value", "valLabel")]
   names(change_table) <- c("varName", "value", "value_new")
-  dat2 <- recode_dat(dat, changeTable = change_table)
+  dat2 <- recode_dat(dat, changeTable = change_table, removeNAs = FALSE)
 
   # identify modified variables
   is_character_old <- unlist(lapply(dat, function(var) is.character(var)))
@@ -201,11 +201,13 @@ labels2values2 <- function(dat, labels, convertMiss, dropPartialLabels, labels2c
   changed_variables_labels2factor <- intersect(labels2factor, changed_variables)
   changed_variables <- setdiff(changed_variables, changed_variables_labels2factor)
   if(length(changed_variables_labels2factor) > 0) {
-    dat2 <- char2fac(dat = dat2, labels = change_labels, vars = changed_variables_labels2factor, convertMiss = convertMiss, ordered = FALSE)
+    dat2 <- char2fac(dat = dat2, ori_dat = dat,
+                     labels = change_labels, vars = changed_variables_labels2factor, convertMiss = convertMiss, ordered = FALSE)
   }
   changed_variables_labels2ordered <- intersect(labels2ordered, changed_variables)
   if(length(changed_variables_labels2ordered) > 0) {
-    dat2 <- char2fac(dat = dat2, labels = change_labels, vars = changed_variables_labels2ordered, convertMiss = convertMiss, ordered = TRUE)
+    dat2 <- char2fac(dat = dat2, ori_dat = dat,
+                     labels = change_labels, vars = changed_variables_labels2ordered, convertMiss = convertMiss, ordered = TRUE)
   }
   dat2
 }
@@ -231,7 +233,7 @@ check_labels <- function(varName, dat, labels, convertMiss) {
 }
 
 # convert characters to factor if specified (keep ordering if possible)
-char2fac <- function(dat, labels, vars, convertMiss, ordered = FALSE) {
+char2fac <- function(dat, ori_dat, labels, vars, convertMiss, ordered = FALSE) {
   partially_labeled <- unordered_facs <- vars
   for(i in vars) {
     fac_meta <- labels[labels$varName == i & (is.na(labels$missings) | labels$missings != "miss")  , c("value", "valLabel")]
@@ -248,7 +250,7 @@ char2fac <- function(dat, labels, vars, convertMiss, ordered = FALSE) {
       partially_labeled <- partially_labeled[partially_labeled != i]
       if(all(fac_meta$value == seq(nrow(fac_meta)))) unordered_facs <- unordered_facs[unordered_facs != i]
 
-      dat[, i] <- factor(dat[, i], levels = fac_meta$valLabel, ordered = ordered)
+      dat[, i] <- factor(ori_dat[, i], levels = fac_meta$value, labels = fac_meta$valLabel, ordered = ordered)
     }
   }
 

--- a/tests/testthat/test_extractData.R
+++ b/tests/testthat/test_extractData.R
@@ -70,19 +70,6 @@ test_that("Extract data into factor with duplicate value labels", {
   expect_equal(out2$VAR1, out_factor2)
 })
 
-
-test_that("char2fac", {
-  df <- data.frame(v1 = factor(c("z", "a", "b"), levels = c("z", "a", "b")),
-                   stringsAsFactors = TRUE)
-  gads <- import_DF(df)
-  dat <- extractData(gads, convertLabels = "character")
-
-  out <- char2fac(dat, labels = gads$labels, vars = "v1", convertMiss = TRUE)
-  expect_true(is.factor(out$v1))
-  expect_false(is.ordered(out$v1))
-  expect_equal(as.numeric(out$v1), c(1:3))
-})
-
 test_that("varlabels_as_labels", {
   df <- varLabels_as_labels(testM$dat, labels = testM$labels)
 

--- a/tests/testthat/test_extractData2.R
+++ b/tests/testthat/test_extractData2.R
@@ -92,14 +92,13 @@ test_that("Extract data into factor with duplicate value labels but only on miss
 test_that("Extract data into factor with one value label being NA", {
   testM3 <- changeValLabels(testM2, varName = "VAR1", value = 2, valLabel = NA)
 
-  # values tagged as missing converted to NA and both valid values have NA as value label
   out <- extractData2(testM3, labels2character = "VAR1", convertMiss = TRUE)
   expect_equal(as.character(out$VAR1), c("One", NA, NA, NA))
 
   outF <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE)
-  fac <- as.factor(c("One", NA, NA, NA))
+  fac <- factor(c(1, NA, NA, 2), levels = 1:2, labels = c("One", NA))
   attr(fac, "label") <- "Variable 1"
-  expect_equal(outF$VAR1, empty_fac)
+  expect_equal(outF$VAR1, fac)
 })
 
 test_that("Extract data into factor with multiple value labels being NA", {
@@ -111,7 +110,7 @@ test_that("Extract data into factor with multiple value labels being NA", {
   expect_equal(as.character(out$VAR1), c(NA, NA_character_, NA, NA))
 
   suppressWarnings(outF <- extractData2(testM3, labels2factor = "VAR1", convertMiss = TRUE))
-  empty_fac <- as.factor(rep(NA, 4))
+  empty_fac <- factor(c(1, NA, NA, 1), levels = 1, labels =  NA)
   attr(empty_fac, "label") <- "Variable 1"
   expect_equal(outF$VAR1, empty_fac)
 })
@@ -127,21 +126,16 @@ test_that("Extract data for strings into factors and ordered", {
   expect_equal(out$Var_char2, as.ordered(c("b_value", "b_value", "b_value", "b_value")))
 })
 
-
 test_that("char2fac", {
   df <- data.frame(v1 = factor(c("z", "a", "b"), levels = c("z", "a", "b")),
                    stringsAsFactors = TRUE)
   gads <- import_DF(df)
+  dat <- extractData(gads, convertLabels = "character")
 
-  dat <- extractData2(gads, labels2character = NULL, labels2factor = namesGADS(gads))
-  out <- char2fac(dat, labels = gads$labels, vars = "v1", convertMiss = TRUE)
+  out <- char2fac(dat, ori_dat = gads$dat, labels = gads$labels, vars = "v1", convertMiss = TRUE)
   expect_true(is.factor(out$v1))
+  expect_false(is.ordered(out$v1))
   expect_equal(as.numeric(out$v1), c(1:3))
-
-  out2 <- char2fac(dat, labels = gads$labels, vars = "v1", convertMiss = TRUE, ordered = TRUE)
-  expect_true(is.factor(out2$v1))
-  expect_true(is.ordered(out2$v1))
-  expect_equal(as.numeric(out2$v1), c(1:3))
 })
 
 test_that("varlabels_as_labels", {


### PR DESCRIPTION
This bug fix addresses superfluous warnings produced by `extractData2()` for duplicate value labels which are also tagged as missing and converted to `NA` anyway. This closes #98.

Furthermore, this function provides consistent treatment of values which have `NA` as value label: When transformed to character, they are simply `NA`, if transformed to factor they get a valid label which is `NA`.

While doing this I realized that `extractData2()` should probably be refactored. It currently transforms all `labels2factor` and `labels2ordered` to character as well, which is simply unnceseary, computationally expensive and complicates code. Will open a separate issue for this.