### PR TITLE
Bugfix/102 inspect meta differences row names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 ## bug fixes
 * `extractData2()` and `extractData()` no longer throw an error if multiple values of the same variable are labelled `NA` (#96)
 * `extractData2()` and `extractData()` no longer produce an error if there are multiple duplicate value labels in a variable 
-* `extractData2()` and `extractData()` no longer produce a warning if multiple duplicate value labels occur which are tagged
-and transformed to `NA` anyway (#98)
+* `extractData2()` and `extractData()` no longer produce a warning if multiple duplicate value labels occur which are tagged and transformed to `NA` anyway (#98)
 * `extractData2()` and `extractData()` now provide consistent output for values which have `NA` as value label (#100)
+* `inspectMetaDifferences()` now correctly reports differences for meta data with differing row names (#102)
 
 # eatGADS 1.1.1
 ## new features

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -92,7 +92,7 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
       if(nrow(meta_row1) == 0) meta_row1[1, ] <- NA
       if(nrow(meta_row2) == 0) meta_row2[1, ] <- NA
       valDiff_new <- data.frame(value = val, meta_row1[, 3:4], meta_row2[, 3:4])
-      #row.names(meta_row1) <- row.names(meta_row2) <- NULL
+      row.names(meta_row1) <- row.names(meta_row2) <- NULL
       if(!identical(meta_row1, meta_row2)) valDiff <- rbind(valDiff, valDiff_new)
     }
     valDiff <- valDiff[order(valDiff$value), ]

--- a/R/inspectMetaDifferences.R
+++ b/R/inspectMetaDifferences.R
@@ -87,12 +87,12 @@ inspectMetaDifferences <- function(GADSdat, varName, other_GADSdat = GADSdat, ot
 
     all_values <- unique(stats::na.omit(c(metaVal1$value, metaVal2$value)))
     for(val in all_values) {
-      #browser()
       meta_row1 <- metaVal1[metaVal1$value == val, ]
       meta_row2 <- metaVal2[metaVal2$value == val, ]
       if(nrow(meta_row1) == 0) meta_row1[1, ] <- NA
       if(nrow(meta_row2) == 0) meta_row2[1, ] <- NA
       valDiff_new <- data.frame(value = val, meta_row1[, 3:4], meta_row2[, 3:4])
+      #row.names(meta_row1) <- row.names(meta_row2) <- NULL
       if(!identical(meta_row1, meta_row2)) valDiff <- rbind(valDiff, valDiff_new)
     }
     valDiff <- valDiff[order(valDiff$value), ]

--- a/tests/testthat/test_inspectMetaDifferences.R
+++ b/tests/testthat/test_inspectMetaDifferences.R
@@ -25,6 +25,7 @@ test_that("Compare two identical GADSdat objects",{
   expect_equal(out2$valDiff, "all.equal")
 })
 
+
 test_that("Differences on variable level",{
   df1_2 <- changeVarLabels(df1, "V1", "some label")
   out <- inspectMetaDifferences(df1, varName = "V1", other_GADSdat = df1_2)
@@ -66,6 +67,19 @@ test_that("Differences on value level",{
   expect_equal(out3$valDiff[, "value"], 1)
   expect_equal(out3$valDiff[, "GADSdat_missings"], c("miss"))
   expect_equal(out3$valDiff[, "other_GADSdat_missings"], c("valid"))
+})
+
+# inspectMetaDifferences should ignore differences in row.names
+test_that("Differences on value level which lead to differences in row.names",{
+  gads1 <- import_DF(data.frame(var1 = 1:4))
+  gads1 <- changeValLabels(gads1, varName = "var1", value = 1:4, valLabel = paste0("Value ", 1:4))
+  gads1 <- changeMissings(gads1, varName = "var1", value = 99, missings = "miss")
+  gads2 <- changeValLabels(gads1, varName = "var1", value = 2, valLabel = "Value 2b")
+  gads2 <- changeMissings(gads2, varName = "var1", value = -99, missings = "miss")
+
+  out <- inspectMetaDifferences(gads1, varName = "var1", other_GADSdat = gads2)
+  expect_equal(nrow(out$valDiff), 2)
+  expect_equal(out$valDiff$value, c(-99, 2))
 })
 
 test_that("Differences after recoding",{


### PR DESCRIPTION
This small PR fixes a bug in `inspectMetaDifferences()` which is relevant for the [eatFDZ::compare_data()](https://github.com/beckerbenj/eatFDZ/blob/master/R/compare_data.R) function.

The function incorrectly reported differences in meta data due to differing `row.names`. This PR closes #102.