### PR TITLE
Feature/33 vectorized inputs

### DIFF
--- a/R/changeMissings.R
+++ b/R/changeMissings.R
@@ -54,10 +54,12 @@ changeMissings.GADSdat <- function(GADSdat, varName, value, missings) {
   changeTable <- changeTable_ori
 
   for(single_varName in varName) {
-    existing_values <- value[value %in% changeTable[changeTable$varName == single_varName, "value"]]
-    existing_missings <- missings[value %in% changeTable[changeTable$varName == single_varName, "value"]]
-    new_values <- value[!value %in% changeTable[changeTable$varName == single_varName, "value"]]
-    new_missings <- missings[!value %in% changeTable[changeTable$varName == single_varName, "value"]]
+    is_existing <- value %in% changeTable[changeTable$varName == single_varName, "value"]
+
+    existing_values <- value[is_existing]
+    existing_missings <- missings[is_existing]
+    new_values <- value[!is_existing]
+    new_missings <- missings[!is_existing]
 
     for(i in seq_along(existing_values)) {
       filterValue <- changeTable$varName == single_varName & changeTable$value == existing_values[i]

--- a/R/changeMissings.R
+++ b/R/changeMissings.R
@@ -10,9 +10,10 @@
 #' multiple variables (\code{varName}) at once.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
-#'@param varName Character string of a variable name.
+#'@param varName Character vector containing variable names.
 #'@param value Numeric values.
-#'@param missings Character string of the new missing codes, either \code{"miss"} or \code{"valid"}.
+#'@param missings Character vector of the new missing codes, either \code{"miss"} or \code{"valid"}.
+#'Missings tags are applied in the same ordering as \code{value}.
 #'
 #'@return Returns the \code{GADSdat} object with changed meta data.
 #'

--- a/R/changeSPSSformat.R
+++ b/R/changeSPSSformat.R
@@ -1,21 +1,31 @@
-#### Change spss format
-#############################################################################
+
 #' Change SPSS format.
 #'
-#' Change the SPSS format of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+#' Change the SPSS format of onr or multiple variables as part of a \code{GADSdat} object.
 #'
-#' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+#' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
+#' of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+#'
+#' SPSS format is supplied following SPSS logik. \code{'A'} represents character variables,
+#' \code{'F'} represents numeric variables. The number following this letter represents the maximum width.
+#' Optionally, another number can be added after a dot, representing the number of decimals
+#' in case of a numeric variable. For instance, \code{'F8.2'} is used for a numeric variable with
+#' a maximum width of 8 with 2 decimal numbers.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
-#'@param varName Character string of variable names.
+#'@param varName Character vector of variable names.
 #'@param format A single string containing the new SPSS format, for example 'A25' or 'F10'.
 #'
 #'@return Returns the \code{GADSdat} object with changed meta data..
 #'
 #'@examples
+#' # change SPSS format for a single variable (numeric variable with no decimals)
 #' pisa2 <- changeSPSSformat(pisa, varName = "idstud",
 #'                         format = "F10.0")
 #'
+#' # change SPSS format for multiple variables (numeric variable with no decimals)
+#' pisa2 <- changeSPSSformat(pisa, varName = c("idstud", "idschool"),
+#'                         format = "F10.0")
 #'
 #'@export
 changeSPSSformat <- function(GADSdat, varName, format) {
@@ -24,7 +34,7 @@ changeSPSSformat <- function(GADSdat, varName, format) {
 #'@export
 changeSPSSformat.GADSdat <- function(GADSdat, varName, format) {
   check_GADSdat(GADSdat)
-  if(!all(varName %in% namesGADS(GADSdat))) stop("varName are not all variables in the GADSdat.")
+  check_vars_in_GADSdat(GADSdat, vars = varName, argName = "varName")
   if(!is.character(format) || length(format) != 1) stop("format has to be a single character value.")
   #other format checks performed in applyChangeMeta
 
@@ -42,7 +52,7 @@ changeVarLabels.all_GADSdat <- function(GADSdat, varName, varLabel) {
   stop("This method has not been implemented yet")
 }
 
-
+# used in applyChangeMeta
 check_format_vector <- function(format) {
   format <- format[!is.na(format)]
   if(length(format) == 0) return()

--- a/R/changeSPSSformat.R
+++ b/R/changeSPSSformat.R
@@ -1,7 +1,7 @@
 
 #' Change SPSS format.
 #'
-#' Change the SPSS format of onr or multiple variables as part of a \code{GADSdat} object.
+#' Change the SPSS format of one or multiple variables as part of a \code{GADSdat} object.
 #'
 #' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
 #' of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.

--- a/R/changeSPSSformat.R
+++ b/R/changeSPSSformat.R
@@ -6,7 +6,7 @@
 #' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
 #' of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
 #'
-#' SPSS format is supplied following SPSS logik. \code{'A'} represents character variables,
+#' SPSS format is supplied following SPSS logic. \code{'A'} represents character variables,
 #' \code{'F'} represents numeric variables. The number following this letter represents the maximum width.
 #' Optionally, another number can be added after a dot, representing the number of decimals
 #' in case of a numeric variable. For instance, \code{'F8.2'} is used for a numeric variable with
@@ -21,11 +21,11 @@
 #'@examples
 #' # change SPSS format for a single variable (numeric variable with no decimals)
 #' pisa2 <- changeSPSSformat(pisa, varName = "idstud",
-#'                         format = "F10.0")
+#'                           format = "F10.0")
 #'
 #' # change SPSS format for multiple variables (numeric variable with no decimals)
 #' pisa2 <- changeSPSSformat(pisa, varName = c("idstud", "idschool"),
-#'                         format = "F10.0")
+#'                           format = "F10.0")
 #'
 #'@export
 changeSPSSformat <- function(GADSdat, varName, format) {

--- a/R/changeValLabels.R
+++ b/R/changeValLabels.R
@@ -50,10 +50,12 @@ changeValLabels.GADSdat <- function(GADSdat, varName, value, valLabel) {
   changeTable <- getChangeMeta(GADSdat, level = "value")
 
   for(single_varName in varName) {
-    existing_values <- value[value %in% changeTable[changeTable$varName == single_varName, "value"]]
-    existing_valLabels <- valLabel[value %in% changeTable[changeTable$varName == single_varName, "value"]]
-    new_values <- value[!value %in% changeTable[changeTable$varName == single_varName, "value"]]
-    new_valLabels <- valLabel[!value %in% changeTable[changeTable$varName == single_varName, "value"]]
+    is_existing <- value %in% changeTable[changeTable$varName == single_varName, "value"]
+
+    existing_values <- value[is_existing]
+    existing_valLabels <- valLabel[is_existing]
+    new_values <- value[!is_existing]
+    new_valLabels <- valLabel[!is_existing]
 
     # edit change table
     for(i in seq_along(existing_values)) {

--- a/R/changeValLabels.R
+++ b/R/changeValLabels.R
@@ -2,15 +2,19 @@
 #############################################################################
 #' Change value labels.
 #'
-#' Change or add value labels of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+#' Change or add value labels of one or multiple variables as part of a \code{GADSdat}
+#'  or \code{all_GADSdat} object.
 #'
-#' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and
-#' \code{\link{applyChangeMeta}}.
+#' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
+#' of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+#' The function supports changing multiple value labels (\code{valLabel}) as well as value labels of
+#' multiple variables (\code{varName}) at once.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
-#'@param varName Character string of a variable name.
-#'@param value Numeric values.
-#'@param valLabel Character string of the new value labels.
+#'@param varName Character vector containing variable names.
+#'@param value Numeric values which are being labeled.
+#'@param valLabel Character vector of the new value labels.
+#'Labels are applied in the same ordering as \code{value}.
 #'
 #'@return Returns the \code{GADSdat} object with changed meta data.
 #'
@@ -26,38 +30,53 @@
 #'                              value = c(4, 6, 8),
 #'                              valLabel = c("four", "six", "eight"))
 #'
+#'# Add value labels to multiple variables at once
+#' mtcars_g3 <- changeValLabels(mtcars_g, varName = c("mpg", "cyl", "disp"),
+#'                              value = c(-99, -98),
+#'                              valLabel = c("missing", "not applicable"))
+#'
+#'
 #'@export
 changeValLabels <- function(GADSdat, varName, value, valLabel) {
   UseMethod("changeValLabels")
 }
 #'@export
 changeValLabels.GADSdat <- function(GADSdat, varName, value, valLabel) {
-  checkValLabelInput(varName = varName, value = value, valLabel = valLabel, labels = GADSdat$labels)
+  check_GADSdat(GADSdat)
+  check_vars_in_GADSdat(GADSdat, vars = varName, argName = "varName")
+  if(length(value) != length(valLabel)) {
+    stop("value and valLabel are not of identical length.", call. = FALSE)
+  }
+
   changeTable <- getChangeMeta(GADSdat, level = "value")
 
-  existing_values <- value[value %in% changeTable[changeTable$varName == varName, "value"]]
-  existing_valLabels <- valLabel[value %in% changeTable[changeTable$varName == varName, "value"]]
-  new_values <- value[!value %in% changeTable[changeTable$varName == varName, "value"]]
-  new_valLabels <- valLabel[!value %in% changeTable[changeTable$varName == varName, "value"]]
+  for(single_varName in varName) {
+    existing_values <- value[value %in% changeTable[changeTable$varName == single_varName, "value"]]
+    existing_valLabels <- valLabel[value %in% changeTable[changeTable$varName == single_varName, "value"]]
+    new_values <- value[!value %in% changeTable[changeTable$varName == single_varName, "value"]]
+    new_valLabels <- valLabel[!value %in% changeTable[changeTable$varName == single_varName, "value"]]
 
-  # edit change table
-  for(i in seq_along(existing_values)) {
-    changeTable[changeTable$varName == varName & changeTable$value == existing_values[i],
-                "valLabel_new"] <- existing_valLabels[i]
-  }
-  for(i in seq_along(new_values)) {
-    change_row <- changeTable[changeTable$varName == varName, ][1, ]
-
-    # if no other value labels exist in the first place, omit original row
-    if(i == 1 && nrow(changeTable[changeTable$varName == varName, ]) == 1 && is.na(change_row$value)) {
-      changeTable <- changeTable[changeTable$varName != varName, ]
+    # edit change table
+    for(i in seq_along(existing_values)) {
+      changeTable[changeTable$varName == single_varName & changeTable$value == existing_values[i],
+                  "valLabel_new"] <- existing_valLabels[i]
     }
+    for(i in seq_along(new_values)) {
+      change_row <- changeTable[changeTable$varName == single_varName, ][1, ]
 
-    change_row[, "value"] <- NA
-    change_row[, "value_new"] <- new_values[i]
-    change_row[, "valLabel_new"] <- new_valLabels[i]
-    changeTable <- rbind(changeTable, change_row)
+      # if no other value labels exist in the first place, omit original row
+      if(i == 1 && nrow(changeTable[changeTable$varName == single_varName, ]) == 1 &&
+         is.na(change_row$value)) {
+        changeTable <- changeTable[changeTable$varName != single_varName, ]
+      }
+
+      change_row[, "value"] <- NA
+      change_row[, "value_new"] <- new_values[i]
+      change_row[, "valLabel_new"] <- new_valLabels[i]
+      changeTable <- rbind(changeTable, change_row)
+    }
   }
+
   applyChangeMeta(GADSdat, changeTable = changeTable)
 }
 
@@ -66,12 +85,5 @@ changeValLabels.all_GADSdat <- function(GADSdat, varName, value, valLabel) {
   stop("This method has not been implemented yet")
 }
 
-checkValLabelInput <- function(varName, value, valLabel, labels) {
-  check_single_varName(varName)
-  if(!is.character(varName) || !length(varName) == 1) stop("'varName' is not a character vector of length 1.")
-  if(!varName %in% labels$varName) stop("varName is not a variable name in the GADSdat.")
-  if(length(value) != length(valLabel)) stop("value and valLabel are not of identical length.", call. = FALSE)
-  return()
-}
 
 

--- a/R/changeValLabels.R
+++ b/R/changeValLabels.R
@@ -2,8 +2,7 @@
 #############################################################################
 #' Change value labels.
 #'
-#' Change or add value labels of one or multiple variables as part of a \code{GADSdat}
-#'  or \code{all_GADSdat} object.
+#' Change or add value labels of one or multiple variables as part of a \code{GADSdat} object.
 #'
 #' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
 #' of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.

--- a/R/changeVarLabels.R
+++ b/R/changeVarLabels.R
@@ -1,22 +1,26 @@
-#### Change variable label
-#############################################################################
-#' Change the variable label.
+
+#' Change variable labels.
 #'
-#' Change the variable label of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+#' Change variable labels of one or multiple variables as part of a \code{GADSdat} object.
 #'
-#' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and
-#' \code{\link{applyChangeMeta}}.
+#' Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
+#' of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
-#'@param varName Character string of variable names.
-#'@param varLabel Character string of the new variable labels.
+#'@param varName Character vector of variable names.
+#'@param varLabel Character vector of the new variable labels.
 #'
 #'@return Returns the \code{GADSdat} object with changed meta data.
 #'
 #'@examples
-#'# Change one variable label
+#' # Change one variable label
 #' pisa2 <- changeVarLabels(pisa, varName = "repeated",
 #'                         varLabel = c("Has a grade been repeated?"))
+#'
+#' # Change multiple variable labels
+#' pisa2 <- changeVarLabels(pisa, varName = c("repeated", "gender"),
+#'                         varLabel = c("Has a grade been repeated?",
+#'                                     "Student gender"))
 #'
 #'@export
 changeVarLabels <- function(GADSdat, varName, varLabel) {
@@ -24,7 +28,15 @@ changeVarLabels <- function(GADSdat, varName, varLabel) {
 }
 #'@export
 changeVarLabels.GADSdat <- function(GADSdat, varName, varLabel) {
-  checkVarLabelVector(varName = varName, varLabel = varLabel, dat = GADSdat$dat)
+  check_GADSdat(GADSdat)
+  if(!is.character(varName) || !is.character(varLabel)) {
+    stop("varName and varLabel are not character vectors.")
+  }
+  if(length(varName) != length(varLabel)) {
+    stop("varName and varLabel are not of identical length.", call. = FALSE)
+  }
+  check_vars_in_GADSdat(GADSdat, vars = varName, argName = "varName")
+
   changeTable <- getChangeMeta(GADSdat, level = "variable")
   for(i in seq_along(varName)) {
     changeTable[changeTable$varName == varName[i], "varLabel_new"] <- varLabel[i]
@@ -37,9 +49,3 @@ changeVarLabels.all_GADSdat <- function(GADSdat, varName, varLabel) {
   stop("This method has not been implemented yet")
 }
 
-checkVarLabelVector <- function(varName, varLabel, dat) {
-  if(!is.character(varName) || !is.character(varLabel)) stop("varName and varLabel are not character vectors.")
-  if(length(varName) != length(varLabel)) stop("varName and varLabel are not of identical length.", call. = FALSE)
-  if(!all(varName %in% names(dat))) stop("varName is not a real variable name.", call. = FALSE)
-  return()
-}

--- a/R/changeVarLabels.R
+++ b/R/changeVarLabels.R
@@ -15,12 +15,12 @@
 #'@examples
 #' # Change one variable label
 #' pisa2 <- changeVarLabels(pisa, varName = "repeated",
-#'                         varLabel = c("Has a grade been repeated?"))
+#'                          varLabel = c("Has a grade been repeated?"))
 #'
 #' # Change multiple variable labels
 #' pisa2 <- changeVarLabels(pisa, varName = c("repeated", "gender"),
-#'                         varLabel = c("Has a grade been repeated?",
-#'                                     "Student gender"))
+#'                          varLabel = c("Has a grade been repeated?",
+#'                                       "Student gender"))
 #'
 #'@export
 changeVarLabels <- function(GADSdat, varName, varLabel) {

--- a/man/changeMissings.Rd
+++ b/man/changeMissings.Rd
@@ -9,11 +9,12 @@ changeMissings(GADSdat, varName, value, missings)
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
-\item{varName}{Character string of a variable name.}
+\item{varName}{Character vector containing variable names.}
 
 \item{value}{Numeric values.}
 
-\item{missings}{Character string of the new missing codes, either \code{"miss"} or \code{"valid"}.}
+\item{missings}{Character vector of the new missing codes, either \code{"miss"} or \code{"valid"}.
+Missings tags are applied in the same ordering as \code{value}.}
 }
 \value{
 Returns the \code{GADSdat} object with changed meta data.

--- a/man/changeMissings.Rd
+++ b/man/changeMissings.Rd
@@ -19,11 +19,13 @@ changeMissings(GADSdat, varName, value, missings)
 Returns the \code{GADSdat} object with changed meta data.
 }
 \description{
-Change or add missing codes of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+Change or add missing codes of one or multiple variables as part of a \code{GADSdat} object.
 }
 \details{
-Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and
-\code{\link{applyChangeMeta}}.
+Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of
+ \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+The function supports changing multiple missing tags (\code{missings}) as well as missing tags of
+multiple variables (\code{varName}) at once.
 }
 \examples{
 # Set a specific value to missing
@@ -38,5 +40,9 @@ pisa3 <- changeMissings(pisa, varName = "computer_age",
 # Set a specific value to not missing
 pisa4 <- changeMissings(pisa2, varName = "computer_age",
                         value = 5, missings = "valid")
+
+# Add missing tags to multiple variables
+pisa5 <- changeMissings(pisa, varName = c("g8g9", "computer_age"),
+                        value = c(-99, -98), missings = c("miss", "miss"))
 
 }

--- a/man/changeSPSSformat.Rd
+++ b/man/changeSPSSformat.Rd
@@ -17,7 +17,7 @@ changeSPSSformat(GADSdat, varName, format)
 Returns the \code{GADSdat} object with changed meta data..
 }
 \description{
-Change the SPSS format of onr or multiple variables as part of a \code{GADSdat} object.
+Change the SPSS format of one or multiple variables as part of a \code{GADSdat} object.
 }
 \details{
 Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper

--- a/man/changeSPSSformat.Rd
+++ b/man/changeSPSSformat.Rd
@@ -23,7 +23,7 @@ Change the SPSS format of one or multiple variables as part of a \code{GADSdat} 
 Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
 of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
 
-SPSS format is supplied following SPSS logik. \code{'A'} represents character variables,
+SPSS format is supplied following SPSS logic. \code{'A'} represents character variables,
 \code{'F'} represents numeric variables. The number following this letter represents the maximum width.
 Optionally, another number can be added after a dot, representing the number of decimals
 in case of a numeric variable. For instance, \code{'F8.2'} is used for a numeric variable with
@@ -32,10 +32,10 @@ a maximum width of 8 with 2 decimal numbers.
 \examples{
 # change SPSS format for a single variable (numeric variable with no decimals)
 pisa2 <- changeSPSSformat(pisa, varName = "idstud",
-                        format = "F10.0")
+                          format = "F10.0")
 
 # change SPSS format for multiple variables (numeric variable with no decimals)
 pisa2 <- changeSPSSformat(pisa, varName = c("idstud", "idschool"),
-                        format = "F10.0")
+                          format = "F10.0")
 
 }

--- a/man/changeSPSSformat.Rd
+++ b/man/changeSPSSformat.Rd
@@ -9,7 +9,7 @@ changeSPSSformat(GADSdat, varName, format)
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
-\item{varName}{Character string of variable names.}
+\item{varName}{Character vector of variable names.}
 
 \item{format}{A single string containing the new SPSS format, for example 'A25' or 'F10'.}
 }
@@ -17,14 +17,25 @@ changeSPSSformat(GADSdat, varName, format)
 Returns the \code{GADSdat} object with changed meta data..
 }
 \description{
-Change the SPSS format of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+Change the SPSS format of onr or multiple variables as part of a \code{GADSdat} object.
 }
 \details{
-Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
+of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+
+SPSS format is supplied following SPSS logik. \code{'A'} represents character variables,
+\code{'F'} represents numeric variables. The number following this letter represents the maximum width.
+Optionally, another number can be added after a dot, representing the number of decimals
+in case of a numeric variable. For instance, \code{'F8.2'} is used for a numeric variable with
+a maximum width of 8 with 2 decimal numbers.
 }
 \examples{
+# change SPSS format for a single variable (numeric variable with no decimals)
 pisa2 <- changeSPSSformat(pisa, varName = "idstud",
                         format = "F10.0")
 
+# change SPSS format for multiple variables (numeric variable with no decimals)
+pisa2 <- changeSPSSformat(pisa, varName = c("idstud", "idschool"),
+                        format = "F10.0")
 
 }

--- a/man/changeValLabels.Rd
+++ b/man/changeValLabels.Rd
@@ -20,8 +20,7 @@ Labels are applied in the same ordering as \code{value}.}
 Returns the \code{GADSdat} object with changed meta data.
 }
 \description{
-Change or add value labels of one or multiple variables as part of a \code{GADSdat}
- or \code{all_GADSdat} object.
+Change or add value labels of one or multiple variables as part of a \code{GADSdat} object.
 }
 \details{
 Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper

--- a/man/changeValLabels.Rd
+++ b/man/changeValLabels.Rd
@@ -9,21 +9,25 @@ changeValLabels(GADSdat, varName, value, valLabel)
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
-\item{varName}{Character string of a variable name.}
+\item{varName}{Character vector containing variable names.}
 
-\item{value}{Numeric values.}
+\item{value}{Numeric values which are being labeled.}
 
-\item{valLabel}{Character string of the new value labels.}
+\item{valLabel}{Character vector of the new value labels.
+Labels are applied in the same ordering as \code{value}.}
 }
 \value{
 Returns the \code{GADSdat} object with changed meta data.
 }
 \description{
-Change or add value labels of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+Change or add value labels of one or multiple variables as part of a \code{GADSdat}
+ or \code{all_GADSdat} object.
 }
 \details{
-Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and
-\code{\link{applyChangeMeta}}.
+Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
+of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
+The function supports changing multiple value labels (\code{valLabel}) as well as value labels of
+multiple variables (\code{varName}) at once.
 }
 \examples{
 # Change existing value labels
@@ -36,5 +40,11 @@ mtcars_g <- import_DF(mtcars)
 mtcars_g2 <- changeValLabels(mtcars_g, varName = "cyl",
                              value = c(4, 6, 8),
                              valLabel = c("four", "six", "eight"))
+
+# Add value labels to multiple variables at once
+mtcars_g3 <- changeValLabels(mtcars_g, varName = c("mpg", "cyl", "disp"),
+                             value = c(-99, -98),
+                             valLabel = c("missing", "not applicable"))
+
 
 }

--- a/man/changeVarLabels.Rd
+++ b/man/changeVarLabels.Rd
@@ -2,30 +2,35 @@
 % Please edit documentation in R/changeVarLabels.R
 \name{changeVarLabels}
 \alias{changeVarLabels}
-\title{Change the variable label.}
+\title{Change variable labels.}
 \usage{
 changeVarLabels(GADSdat, varName, varLabel)
 }
 \arguments{
 \item{GADSdat}{\code{GADSdat} object imported via \code{eatGADS}.}
 
-\item{varName}{Character string of variable names.}
+\item{varName}{Character vector of variable names.}
 
-\item{varLabel}{Character string of the new variable labels.}
+\item{varLabel}{Character vector of the new variable labels.}
 }
 \value{
 Returns the \code{GADSdat} object with changed meta data.
 }
 \description{
-Change the variable label of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+Change variable labels of one or multiple variables as part of a \code{GADSdat} object.
 }
 \details{
-Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper of \code{\link{getChangeMeta}} and
-\code{\link{applyChangeMeta}}.
+Applied to a \code{GADSdat} or \code{all_GADSdat} object, this function is a wrapper
+of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
 }
 \examples{
 # Change one variable label
 pisa2 <- changeVarLabels(pisa, varName = "repeated",
                         varLabel = c("Has a grade been repeated?"))
+
+# Change multiple variable labels
+pisa2 <- changeVarLabels(pisa, varName = c("repeated", "gender"),
+                        varLabel = c("Has a grade been repeated?",
+                                    "Student gender"))
 
 }

--- a/man/changeVarLabels.Rd
+++ b/man/changeVarLabels.Rd
@@ -26,11 +26,11 @@ of \code{\link{getChangeMeta}} and \code{\link{applyChangeMeta}}.
 \examples{
 # Change one variable label
 pisa2 <- changeVarLabels(pisa, varName = "repeated",
-                        varLabel = c("Has a grade been repeated?"))
+                         varLabel = c("Has a grade been repeated?"))
 
 # Change multiple variable labels
 pisa2 <- changeVarLabels(pisa, varName = c("repeated", "gender"),
-                        varLabel = c("Has a grade been repeated?",
-                                    "Student gender"))
+                         varLabel = c("Has a grade been repeated?",
+                                      "Student gender"))
 
 }

--- a/tests/testthat/test_changeMissings.R
+++ b/tests/testthat/test_changeMissings.R
@@ -89,15 +89,17 @@ test_that("changeMissings for multiple variables at once",{
   out <- changeMissings(dfSAV, varName = c("VAR1", "VAR2"), value = c(1, 2),
                         missings = c("miss", "valid"))
 
-  expect_equal(nrow(out$labels[out$labels$varName == "VAR1", ]), 4)
-  expect_equal(out$labels[3, "missings"], "miss")
-  expect_equal(out$labels[4, "missings"], "valid")
+  out_labels_var1 <- out$labels[out$labels$varName == "VAR1", ]
+  expect_equal(nrow(out_labels_var1), 4)
+  expect_equal(out_labels_var1[out_labels_var1$value == 1, "missings"], "miss")
+  expect_equal(out_labels_var1[out_labels_var1$value == 2, "missings"], "valid")
   expect_equal(out$labels[3, "value"], 1)
   expect_equal(out$labels[4, "value"], 2)
 
-  expect_equal(nrow(out$labels[out$labels$varName == "VAR2", ]), 4)
-  expect_equal(out$labels[7, "missings"], "miss")
-  expect_equal(out$labels[8, "missings"], "valid")
-  expect_equal(out$labels[7, "value"], 1)
-  expect_equal(out$labels[8, "value"], 2)
+  out_labels_var2 <- out$labels[out$labels$varName == "VAR2", ]
+  expect_equal(nrow(out_labels_var1), 4)
+  expect_equal(out_labels_var2[out_labels_var2$value == 1, "missings"], "miss")
+  expect_equal(out_labels_var2[out_labels_var2$value == 2, "missings"], "valid")
+  expect_equal(out$labels[3, "value"], 1)
+  expect_equal(out$labels[4, "value"], 2)
 })

--- a/tests/testthat/test_changeValLabels.R
+++ b/tests/testthat/test_changeValLabels.R
@@ -1,12 +1,12 @@
 
 dfSAV <- import_spss(file = test_path("helper_spss_missings.sav"))
-
 dfUn <- import_DF(data.frame(v1 = 1, v2 = 2))
 
 test_that("changeValLabel input validation", {
   expect_error(changeValLabels(dfSAV, varName = c("VAR1"), value = 1:2, valLabel = "test label"),
                "value and valLabel are not of identical length.")
-  expect_error(changeValLabels(dfSAV, varName = c("VAR4"), value = 1, valLabel = "test label"))
+  expect_error(changeValLabels(dfSAV, varName = c("VAR4"), value = 1, valLabel = "test label"),
+               "The following 'varName' are not variables in the GADSdat: VAR4")
 })
 
 test_that("changevallabel wrapper", {

--- a/tests/testthat/test_changeValLabels.R
+++ b/tests/testthat/test_changeValLabels.R
@@ -1,21 +1,24 @@
 
-# dfSAV <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
-dfSAV <- import_spss(file = "helper_spss_missings.sav")
+dfSAV <- import_spss(file = test_path("helper_spss_missings.sav"))
 
 dfUn <- import_DF(data.frame(v1 = 1, v2 = 2))
+
+test_that("changeValLabel input validation", {
+  expect_error(changeValLabels(dfSAV, varName = c("VAR1"), value = 1:2, valLabel = "test label"),
+               "value and valLabel are not of identical length.")
+  expect_error(changeValLabels(dfSAV, varName = c("VAR4"), value = 1, valLabel = "test label"))
+})
 
 test_that("changevallabel wrapper", {
   out <- changeValLabels(dfSAV, varName = "VAR1", value = 1, valLabel = "test label")
   expect_equal(out$labels[3, "valLabel"], "test label")
   expect_equal(out$dat, dfSAV$dat)
 
-  out2 <- changeValLabels(dfSAV, varName = "VAR2", value = c(-99, -96), valLabel = c("label 3", "label 2"))
+  out2 <- changeValLabels(dfSAV, varName = "VAR2", value = c(-99, -96),
+                          valLabel = c("label 3", "label 2"))
   expect_equal(out2$labels[c(4, 5), "value"], c(-99, -96))
   expect_equal(out2$labels[c(4, 5), "valLabel"], c("label 3", "label 2"))
   expect_equal(out2$dat, dfSAV$dat)
-
-  expect_error(changeValLabels(dfSAV, varName = c("VAR1", "VAR2"), value = 1, valLabel = "test label"))
-  expect_error(changeValLabels(dfSAV, varName = c("VAR4"), value = 1, valLabel = "test label"))
 })
 
 
@@ -67,3 +70,13 @@ test_that("add value label to a variable with multiple existing and multiple new
   expect_equal(out$labels$valLabel[1:5], paste0("miss", 1:5))
 })
 
+test_that("changeValLabels for multiple variables at once", {
+  out <- changeValLabels(dfSAV, varName = c("VAR1", "VAR2"),
+                         value = c(-99, -98, -97, -96, -95),
+                         valLabel = c("miss1", "miss2", "miss3", "miss4", "miss5"))
+  expect_equal(out$labels$value[1:5], -99:-95)
+  expect_equal(out$labels$value[7:11], -99:-95)
+  expect_equal(out$labels$valLabel[1:5], paste0("miss", 1:5))
+  expect_equal(out$labels$valLabel[7:11], paste0("miss", 1:5))
+
+})


### PR DESCRIPTION
This PR addresses #33 and extends `changeValLabels()` and `changeMissings()` to perform changes to multiple variables (argument `varName`) via a single function call. Furthermore, input validation and documentation for these functions is cleaned up and standardized.

For `changeSPSSformat()` and `changeVarLabels()` (which already allowed changing multiple variables), input validation and documentation is also cleaned up and standardized.

For `recodeGADS()`, the same feature will be tackled in a separate issue (see #107) and PR.

Feature requested for the data cleaning of BT24 by @liebelta, @OtteKatrin and @burbliesj. One review suffices