### PR TITLE
Bugfix/104 recode gads existing meta

### DIFF
--- a/R/applyChangeMeta.R
+++ b/R/applyChangeMeta.R
@@ -236,11 +236,12 @@ recode_labels <- function(labels, changeTable, existingMeta) {
     }
 
     # meta data conflicts with old values (and optionally new values)
-    #if(any(existing_value_not_recoded_into_logical)){
-    if(any(existing_value_logical)){
+    if(any(existing_value_not_recoded_into_logical)){
+    #if(any(existing_value_logical)){  ##
       ## One could argue that this should be existing_value_logical instead. However, this breaks a lot if existing
       ## code, for instance changeMissings(). When recode_labels() is refactored, this should be reconsidered!
-      if(identical(existingMeta, "stop") && any(existing_value_not_recoded_into_logical)) {
+      if(identical(existingMeta, "stop")) {
+      #if(identical(existingMeta, "stop") && any(existing_value_not_recoded_into_logical)) {
         all_values <- existing_value_not_recoded_into_vec
         stop("Values in 'value_new' with existing meta data in variable ", var_name, ": ",
                                                paste(all_values, collapse = ", "))

--- a/R/applyChangeMeta.R
+++ b/R/applyChangeMeta.R
@@ -201,18 +201,18 @@ recode_labels <- function(labels, changeTable, existingMeta) {
       single_simpleChanges$value_new %in% single_labels$value
     existing_value_vec <- single_simpleChanges$value_new[existing_value_logical]
 
-    existing_value_not_recoded_into_logical <- existing_value_logical &
+    existing_value_not_recoded_itself_logical <- existing_value_logical &
       !single_simpleChanges$value_new %in% values_being_recoded
-    existing_value_not_recoded_into_vec <- single_simpleChanges$value_new[existing_value_not_recoded_into_logical]
-
+    existing_value_not_recoded_itself_vec <- single_simpleChanges$value_new[existing_value_not_recoded_itself_logical]
+    #if(length(existing_value_not_recoded_itself_vec) > 0) browser()
     remove_rows <- numeric()
 
     # meta data conflicts only with new values
     recode_values <- single_simpleChanges$value_new[!is.na(single_simpleChanges$value_new)]
-    only_new_recode_values <- recode_values[!recode_values %in% existing_value_not_recoded_into_vec]
+    only_new_recode_values <- recode_values[!recode_values %in% existing_value_not_recoded_itself_vec]
     dup_recode_values <- unique(only_new_recode_values[duplicated(only_new_recode_values)])
     dup_recode_values <- dup_recode_values[!dup_recode_values %in%
-                                             single_simpleChanges[existing_value_not_recoded_into_logical, "value"]]
+                                             single_simpleChanges[existing_value_not_recoded_itself_logical, "value"]]
     new_dup_value_vec <- !is.na(single_simpleChanges$value_new) & single_simpleChanges$value_new %in% dup_recode_values
 
     #browser()
@@ -221,9 +221,8 @@ recode_labels <- function(labels, changeTable, existingMeta) {
       single_simpleChanges[new_dup_value_vec | existing_value_logical, "value_new"] <- NA
     }
 
-    if(length(dup_recode_values) > 0 && !all(dup_recode_values %in% existing_value_not_recoded_into_vec)){
+    if(length(dup_recode_values) > 0 && !all(dup_recode_values %in% existing_value_not_recoded_itself_vec)){
       if(!(identical(existingMeta, "drop") || identical(existingMeta, "ignore"))) {
-        all_values <- existing_value_not_recoded_into_vec
         stop("Duplicated values in 'value_new' causing conflicting meta data in variable ", var_name, ": ",
              paste(dup_recode_values, collapse = ", "), ". Use existingMeta = 'drop' or 'ignore' to drop all related meta data.")
       }
@@ -236,19 +235,18 @@ recode_labels <- function(labels, changeTable, existingMeta) {
     }
 
     # meta data conflicts with old values (and optionally new values)
-    if(any(existing_value_not_recoded_into_logical)){
+    if(any(existing_value_not_recoded_itself_logical)){
     #if(any(existing_value_logical)){  ##
       ## One could argue that this should be existing_value_logical instead. However, this breaks a lot if existing
       ## code, for instance changeMissings(). When recode_labels() is refactored, this should be reconsidered!
       if(identical(existingMeta, "stop")) {
-      #if(identical(existingMeta, "stop") && any(existing_value_not_recoded_into_logical)) {
-        all_values <- existing_value_not_recoded_into_vec
+      #if(identical(existingMeta, "stop") && any(existing_value_not_recoded_itself_logical)) {
         stop("Values in 'value_new' with existing meta data in variable ", var_name, ": ",
-                                               paste(all_values, collapse = ", "))
+              paste(existing_value_not_recoded_itself_vec, collapse = ", "))
       }
       if(identical(existingMeta, "value")) {
         # remove meta data of value which is being recoded
-        remove_value_meta <- existing_value_not_recoded_into_vec
+        remove_value_meta <- existing_value_not_recoded_itself_vec
         remove_rows <- which(single_labels$value %in% remove_value_meta)
         dups <- duplicated(remove_value_meta)
         if(any(dups)) stop("Multiple values are recoded into ", remove_value_meta[dups], " for variable ",
@@ -271,8 +269,8 @@ recode_labels <- function(labels, changeTable, existingMeta) {
       }
       if(identical(existingMeta, "drop")) {
         #remove_value_meta <- single_simpleChanges[existing_value_logical, "value_new"]
-        remove_value_meta <- existing_value_not_recoded_into_vec
-        remove_value_meta <- unique(c(remove_value_meta, single_simpleChanges[existing_value_not_recoded_into_logical, "value"]))
+        remove_value_meta <- existing_value_not_recoded_itself_vec
+        remove_value_meta <- unique(c(remove_value_meta, single_simpleChanges[existing_value_not_recoded_itself_logical, "value"]))
         drop_meta_rows <- which(single_labels$value %in% remove_value_meta)
         single_labels[drop_meta_rows, c("valLabel", "missings")] <- NA
       }

--- a/tests/testthat/test_applyChangeMeta.R
+++ b/tests/testthat/test_applyChangeMeta.R
@@ -1,8 +1,6 @@
 
-# load(file = "tests/testthat/helper_data.rda")
-load(file = "helper_data.rda")
-# dfSAV <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
-dfSAV <- import_spss(file = "helper_spss_missings.sav")
+load(file = test_path("helper_data.rda"))
+dfSAV <- import_spss(file = test_path("helper_spss_missings.sav"))
 
 ### Meta changes
 changes_var <- getChangeMeta(dfSAV)
@@ -78,6 +76,7 @@ test_that("Recoding with value meta data conflicts", {
   changes_val2[1, "value_new"] <- 1
   expect_error(recode_labels(dfSAV$labels, changes_val2, existingMeta = "stop"),
                "Values in 'value_new' with existing meta data in variable VAR1: 1")
+
   out <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "value")
   comp1 <- dfSAV$labels[-3, ]
   comp1[1, "value"] <- 1
@@ -93,6 +92,33 @@ test_that("Recoding with value meta data conflicts", {
   comp2 <- comp2[c(2, 1, 3:6),]
   rownames(comp2) <- NULL
   expect_equal(comp2, out2)
+
+  out3 <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "ignore")
+  expect_equal(dfSAV$labels, out3)
+})
+
+test_that("Recoding values into each other (with value meta data conflicts)", {
+  changes_val2 <- changes_val
+  changes_val2[1, "value_new"] <- 1
+  changes_val2[3, "value_new"] <- -99
+
+  ## see source code, one could argue that this should throw an error!
+  #expect_error(recode_labels(dfSAV$labels, changes_val2, existingMeta = "stop"),
+  #             "Values in 'value_new' with existing meta data in variable VAR1: 1")
+
+  out <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "value")
+  comp1 <- dfSAV$labels
+  comp1[1, "value"] <- 1
+  comp1[3, "value"] <- -99
+  comp1 <- comp1[c(3, 2, 1, 4:7),]
+  rownames(comp1) <- NULL
+  expect_equal(comp1, out)
+
+  out2 <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "value_new")
+  expect_equal(dfSAV$labels, out2)
+
+  out3 <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "ignore")
+  expect_equal(dfSAV$labels, out3)
 })
 
 test_that("Recoding multiple value into the same value (without meta data conflicts)", {

--- a/tests/testthat/test_applyChangeMeta.R
+++ b/tests/testthat/test_applyChangeMeta.R
@@ -101,6 +101,7 @@ test_that("Recoding values into each other (with value meta data conflicts)", {
   changes_val2 <- changes_val
   changes_val2[1, "value_new"] <- 1
   changes_val2[3, "value_new"] <- -99
+  #changes_val2[3, "value_new"] <- -96      ## maybe this would be a better test as complete functionality is covered?
 
   ## see source code, one could argue that this should throw an error!
   #expect_error(recode_labels(dfSAV$labels, changes_val2, existingMeta = "stop"),

--- a/tests/testthat/test_applyChangeMeta.R
+++ b/tests/testthat/test_applyChangeMeta.R
@@ -114,8 +114,10 @@ test_that("Recoding values into each other (with value meta data conflicts)", {
   rownames(comp1) <- NULL
   expect_equal(comp1, out)
 
-  out2 <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "value_new")
-  expect_equal(dfSAV$labels, out2)
+  ## hotfix (11.11.2024) allows this to work with 'ignore', but still does not work for 'value_new'
+  ## should be fixed when refactoring recode_labels()
+  #out2 <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "value_new")
+  #expect_equal(dfSAV$labels, out2)
 
   out3 <- recode_labels(dfSAV$labels, changes_val2, existingMeta = "ignore")
   expect_equal(dfSAV$labels, out3)


### PR DESCRIPTION
This is a hot fix which partly addresses #104. In the current layout, `recode_labels()` works very differently if values are being recoded into themselves or not. This leads to very surprising behavior regarding the `existingMeta` argument if, for instance, two values are recoded into each other.

This PR is a hotfix and only fixes the function behavior for `existingMeta = "ignore"`. Due to time constraints a complete refactoring of recode_labels (see #59) is postponed but seems necessary to fully cover the complete `existingMeta` functionality.

@liebelta, @OtteKatrin and @burbliesj: Could you live with `existingMeta = "ignore"` simply leaving meta data untouched and other options not being available?

One review suffices.