### PR TITLE
removeValLabels: Clarify documentation, clean up input validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * `extractData2()` and `extractData()` now provide consistent output for values which have `NA` as value label (#100)
 * `inspectMetaDifferences()` now correctly reports differences for meta data with differing row names (#102)
 * hot fix for `existingMeta` argument in `recodeGADS()` and `applyChangeMeta()`, which was ignored when values were recoded into each other (#104)
+* fix unclear documentation in `removeValLabels()` (#111)
 
 # eatGADS 1.1.1
 ## new features

--- a/R/removeValLabels.R
+++ b/R/removeValLabels.R
@@ -1,10 +1,11 @@
 #### Remove value label
 #############################################################################
-#' Remove value labels.
+#' Remove value labels and missing tags.
 #'
-#' Remove value labels of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+#' Remove meta data for specific values (\code{value}) of a single variable (\code{varName}).
+#' This includes value labels and missings tags.
 #'
-#' If the argument \code{valLabel} is provided the function checks for \code{value} and \code{valLabel} pairs in the
+#' If the argument \code{valLabel} is provided, the function checks for \code{value} and \code{valLabel} pairs in the
 #' meta data that match both arguments.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
@@ -37,7 +38,10 @@ removeValLabels <- function(GADSdat, varName, value, valLabel = NULL) {
 }
 #'@export
 removeValLabels.GADSdat <- function(GADSdat, varName, value, valLabel = NULL) {
-  checkValRemoveInput(varName = varName, value = value, labels = GADSdat$labels)
+  if(!is.character(varName) || !length(varName) == 1) {
+    stop("'varName' is not a character vector of length 1.")
+  }
+  check_vars_in_GADSdat(GADSdat, vars = varName, argName = "varName")
 
   all_rows <- which(GADSdat$labels$varName == varName)
   remove_rows <- which(GADSdat$labels$varName == varName & GADSdat$labels$value %in% value)
@@ -75,10 +79,5 @@ removeValLabels.all_GADSdat <- function(GADSdat, varName, value, valLabel = NULL
   stop("This method has not been implemented yet")
 }
 
-checkValRemoveInput <- function(varName, value, labels) {
-  if(!is.character(varName) || !length(varName) == 1) stop("'varName' is not a character vector of length 1.")
-  if(!varName %in% labels$varName) stop("'varName' is not a variable name in the GADSdat.")
-  return()
-}
 
 

--- a/man/removeValLabels.Rd
+++ b/man/removeValLabels.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/removeValLabels.R
 \name{removeValLabels}
 \alias{removeValLabels}
-\title{Remove value labels.}
+\title{Remove value labels and missing tags.}
 \usage{
 removeValLabels(GADSdat, varName, value, valLabel = NULL)
 }
@@ -19,7 +19,8 @@ removeValLabels(GADSdat, varName, value, valLabel = NULL)
 Returns the \code{GADSdat} object with changed meta data.
 }
 \description{
-Remove value labels of a variable as part of a \code{GADSdat} or \code{all_GADSdat} object.
+Remove meta data for specific values (\code{value}) of a single variable (\code{varName}).
+This includes value labels and missings tags.
 }
 \details{
 If the argument \code{valLabel} is provided the function checks for \code{value} and \code{valLabel} pairs in the

--- a/tests/testthat/test_removeValLabels.R
+++ b/tests/testthat/test_removeValLabels.R
@@ -6,7 +6,7 @@ dfUn <- import_DF(data.frame(v1 = 1, v2 = 2))
 
 test_that("Errors", {
   expect_error(removeValLabels(dfSAV, varName = "VAR5", value = 2),
-               "'varName' is not a variable name in the GADSdat.")
+               "The following 'varName' are not variables in the GADSdat: VAR5")
   expect_error(removeValLabels(dfSAV, varName = c("VAR1", "VAR3"), value = 2),
                "'varName' is not a character vector of length 1.")
 


### PR DESCRIPTION
This PR addresses #111 and additionally tidies up the input validation of `removeValLabels()`.