### PR TITLE
merge.GADSdat: Add automatic recoding of NAs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * `dropDuplicateIDs()` allows dropping duplicate IDs based on number of missings on selected variables (#67)
 * `changeValLabels()` and `changeMissings()` allow changing value labels and missing tags for multiple variables at once (#33)
 * `recodeGADS()` allows recoding multiple variables at once (#107)
+* `merge.GADSdat()` allows automatically assigning NAs created through merging a missing code and a value label (#1)
 
 ## bug fixes
 * `extractData2()` and `extractData()` no longer throw an error if multiple values of the same variable are labeled `NA` (#96)

--- a/R/merge.R
+++ b/R/merge.R
@@ -2,10 +2,14 @@
 #############################################################################
 #' Merge two \code{GADSdat} objects into a single \code{GADSdat} object.
 #'
-#' Is a secure way to merge the data and the meta data of two \code{GADSdat} objects. Currently, only limited merging options are supported.
+#' Is a secure way to merge the data and the meta data of two \code{GADSdat} objects.
+#' Currently, only limited merging options are supported.
 #'
 #' If there are duplicate variables (except the variables specified in the \code{by} argument), these variables are removed from y.
 #' The meta data is joined for the remaining variables via \code{rbind}.
+#'
+#' The function supports automatically recoding missing values created through merging with a designated missing code
+#' (\code{missingValue}) and a value label (\code{missingValLabel}).
 #'
 #'@param x \code{GADSdat} object imported via \code{eatGADS}.
 #'@param y \code{GADSdat} object imported via \code{eatGADS}.
@@ -13,26 +17,63 @@
 #'@param all A character vector (either a full join or an inner join).
 #'@param all.x See merge.
 #'@param all.y See merge.
+#'@param missingValue A numeric value that is used to replace missing values introduced through the merge.
+#'@param missingValLabel The value label that is assigned to all variables into which \code{missingValue} is inserted.
 #'@param ... Further arguments are currently not supported but have to be included for \code{R CMD} checks.
 #'
 #'@return Returns a \code{GADSdat} object.
 #'
 #'
 #'@export
-merge.GADSdat <- function(x, y, by, all = TRUE, all.x = all, all.y = all, ...) {
+merge.GADSdat <- function(x, y, by, all = TRUE, all.x = all, all.y = all,
+                          missingValue = NULL, missingValLabel = NULL, ...) {
   check_GADSdat(x)
   check_GADSdat(y)
-  if(!is.character(by)) stop(by, " is not a character vector.")
-  if(!all(by %in% names(x$dat))) stop(by, " is not a variable in x.")
-  if(!all(by %in% names(y$dat))) stop(by, " is not a variable in y.")
-  # drop double variables from y
+  if(!is.character(by)) {
+    stop(by, " is not a character vector.")
+  }
+  check_vars_in_GADSdat(x, vars = by, argName = "by", GADSdatName = "x")
+  check_vars_in_GADSdat(y, vars = by, argName = "by", GADSdatName = "y")
+
+  # drop duplicate variables from y
   y_vars <- c(by, names(y$dat)[!names(y$dat) %in% names(x$dat)])
-  if(!length(y_vars) > length(by)) stop("y does not contain unique variables.")
+  if(!length(y_vars) > length(by)) {
+    stop("y does not contain unique variables.")
+  }
 
-  newDat <- merge(x$dat, y$dat[, y_vars], by = by, all = all, all.x = all.x, all.y = all.y)
+  # replace NAs in original data sets to be able to recode them after merging
+  if(!is.null(missingValue)) {
+    check_numericArgument(missingValue, argName = "missingValue")
+
+    intermediate_code <- -99.9989
+    if(any(!is.na(x$dat) & x$dat == intermediate_code) || any(!is.na(y$dat) & y$dat == intermediate_code)) {
+      stop("Intermediate code is already in the data.")
+    }
+    x$dat[is.na(x$dat)] <- intermediate_code
+    y$dat[is.na(y$dat)] <- intermediate_code
+  }
+
+  newDat <- merge(x$dat, y$dat[, y_vars], by = by, all = all, all.x = all.x, all.y = all.y, ...)
   newLabels <- rbind(x$labels, y$labels[y$labels$varName %in% y_vars[!y_vars %in% by], ])
-
   newGADS <- new_GADSdat(dat = newDat, labels = newLabels)
   check_GADSdat(GADSdat = newGADS)
+
+  # replace NAs introduced through merging with missingValue and recode original NAs back
+  if(!is.null(missingValue)) {
+    vars_with_missingValue <- colnames(newGADS$dat)[apply(is.na(newGADS$dat), 2, any)]
+    newGADS$dat[is.na(newGADS$dat)] <- missingValue
+    newGADS$dat[newGADS$dat == intermediate_code] <- NA
+
+    for(single_var in vars_with_missingValue) {
+      newGADS <- changeMissings(newGADS, varName = single_var, value = missingValue, missings = "miss")
+    }
+
+    if(!is.null(missingValLabel) && length(vars_with_missingValue) > 0) {
+      check_characterArgument(missingValLabel, argName = "missingValLabel")
+      for(single_var in vars_with_missingValue) {
+        newGADS <- changeValLabels(newGADS, varName = single_var, value = missingValue, valLabel = missingValLabel)
+      }
+    }
+  }
   newGADS
 }

--- a/R/merge.R
+++ b/R/merge.R
@@ -38,19 +38,21 @@ merge.GADSdat <- function(x, y, by, all = TRUE, all.x = all, all.y = all,
   # drop duplicate variables from y
   y_vars <- c(by, names(y$dat)[!names(y$dat) %in% names(x$dat)])
   if(!length(y_vars) > length(by)) {
-    stop("y does not contain unique variables.")
+    stop("y does not contain variables distinct from x.")
   }
 
   # replace NAs in original data sets to be able to recode them after merging
   if(!is.null(missingValue)) {
     check_numericArgument(missingValue, argName = "missingValue")
 
-    intermediate_code <- -99.9989
-    if(any(!is.na(x$dat) & x$dat == intermediate_code) || any(!is.na(y$dat) & y$dat == intermediate_code)) {
-      stop("Intermediate code is already in the data.")
+    if(any(!is.na(x$dat)) || any(!is.na(y$dat))) {
+      intermediate_code <- -99.9989 ## default value
+      while (any(!is.na(x$dat) & x$dat == intermediate_code) || any(!is.na(y$dat) & y$dat == intermediate_code)) {
+        intermediate_code <- runif(1, -1e4, -1e2)  # Generate a random value in a wide range
+      }
+      x$dat[is.na(x$dat)] <- intermediate_code
+      y$dat[is.na(y$dat)] <- intermediate_code
     }
-    x$dat[is.na(x$dat)] <- intermediate_code
-    y$dat[is.na(y$dat)] <- intermediate_code
   }
 
   newDat <- merge(x$dat, y$dat[, y_vars], by = by, all = all, all.x = all.x, all.y = all.y, ...)

--- a/man/merge.GADSdat.Rd
+++ b/man/merge.GADSdat.Rd
@@ -4,7 +4,17 @@
 \alias{merge.GADSdat}
 \title{Merge two \code{GADSdat} objects into a single \code{GADSdat} object.}
 \usage{
-\method{merge}{GADSdat}(x, y, by, all = TRUE, all.x = all, all.y = all, ...)
+\method{merge}{GADSdat}(
+  x,
+  y,
+  by,
+  all = TRUE,
+  all.x = all,
+  all.y = all,
+  missingValue = NULL,
+  missingValLabel = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{\code{GADSdat} object imported via \code{eatGADS}.}
@@ -19,15 +29,23 @@
 
 \item{all.y}{See merge.}
 
+\item{missingValue}{A numeric value that is used to replace missing values introduced through the merge.}
+
+\item{missingValLabel}{The value label that is assigned to all variables into which \code{missingValue} is inserted.}
+
 \item{...}{Further arguments are currently not supported but have to be included for \code{R CMD} checks.}
 }
 \value{
 Returns a \code{GADSdat} object.
 }
 \description{
-Is a secure way to merge the data and the meta data of two \code{GADSdat} objects. Currently, only limited merging options are supported.
+Is a secure way to merge the data and the meta data of two \code{GADSdat} objects.
+Currently, only limited merging options are supported.
 }
 \details{
 If there are duplicate variables (except the variables specified in the \code{by} argument), these variables are removed from y.
 The meta data is joined for the remaining variables via \code{rbind}.
+
+The function supports automatically recoding missing values created through merging with a designated missing code
+(\code{missingValue}) and a value label (\code{missingValLabel}).
 }

--- a/tests/testthat/test_merge.R
+++ b/tests/testthat/test_merge.R
@@ -5,11 +5,17 @@ load(file = test_path("helper_data.rda"))
 mod_dat <- data.frame(ID1 = c(1, 3, 4), V2 = c(8, 10, 9))
 df3 <- suppressMessages(updateMeta(df1, mod_dat))
 
+# data with existing NAs
+df1b <- df1
+df1b$dat[1, "V1"] <- NA
+df3b <- df3
+df3b$dat[2:3, "V2"] <- NA
 
 test_that("Errors for merge", {
   expect_error(merge(df1, df3, by = 2))
   expect_error(merge(df1, df3, by = "x2"))
-  expect_error(merge(df1, df1, by = "V1"))
+  expect_error(merge(df1, df1, by = "V1"),
+               "y does not contain variables distinct from x.")
 })
 
 test_that("Merge two GADSdat objects",{
@@ -26,10 +32,6 @@ test_that("Merge two GADSdat objects while setting default missing value",{
   expect_equal(nrow(out$labels), 3)
 
   # with existing NAs
-  df1b <- df1
-  df1b$dat[1, "V1"] <- NA
-  df3b <- df3
-  df3b$dat[2:3, "V2"] <- NA
   out2 <- merge(df1b, df3b, by = "ID1", missingValue = -99, missingValLabel = "missing")
   expect_equal(out2$dat[, "V1"], c(NA, 5, -99, -99))
   expect_equal(out2$dat[, "V2"], c(8, -99, NA, NA))
@@ -37,6 +39,25 @@ test_that("Merge two GADSdat objects while setting default missing value",{
   expect_equal(out2$labels[2:3, "value"], c(-99, -99))
   expect_equal(out2$labels[2:3, "valLabel"], c("missing", "missing"))
   expect_equal(out2$labels[2:3, "missings"], c("miss", "miss"))
+
+  # with existing NAs
+  out3 <- merge(df1b, df3b, by = "ID1", missingValue = -99)
+  expect_equal(out3$dat[, "V1"], c(NA, 5, -99, -99))
+  expect_equal(out3$dat[, "V2"], c(8, -99, NA, NA))
+  expect_equal(nrow(out3$labels), 3)
+  expect_equal(out3$labels[2:3, "value"], c(-99, -99))
+  expect_equal(out3$labels[2:3, "valLabel"], c(NA_character_, NA))
+  expect_equal(out3$labels[2:3, "missings"], c("miss", "miss"))
+})
+
+test_that("Merge two GADSdat objects while setting default missing value and the default substitution value exists in the data",{
+  df1c <- df1b
+  df1c$dat[2, "V1"] <- -99.9989
+  out <- merge(df1c, df3b, by = "ID1", missingValue = -99, missingValLabel = "missing")
+  expect_equal(out$dat[, "V1"], c(NA, -99.9989, -99, -99))
+  expect_equal(out$dat[, "V2"], c(8, -99, NA, NA))
+  expect_equal(nrow(out$labels), 3)
+  expect_equal(out$labels[2:3, "missings"], c("miss", "miss"))
 })
 
 test_that("Inner join two GADSdat objects", {

--- a/tests/testthat/test_merge.R
+++ b/tests/testthat/test_merge.R
@@ -1,32 +1,45 @@
 
 # load test data (df1, df2, pkList, fkList)
-# load(file = "tests/testthat/helper_data.rda")
-load(file = "helper_data.rda")
+load(file = test_path("helper_data.rda"))
+
+mod_dat <- data.frame(ID1 = c(1, 3, 4), V2 = c(8, 10, 9))
+df3 <- suppressMessages(updateMeta(df1, mod_dat))
 
 
-test_that("Merge two GADSdat objects",{
-  df3 <- df1
-  mod_dat <- df3$dat
-  mod_dat[, "v3"] <- c(8, 7)
-  df3 <- suppressMessages(updateMeta(df3, mod_dat))
+test_that("Errors for merge", {
   expect_error(merge(df1, df3, by = 2))
   expect_error(merge(df1, df3, by = "x2"))
   expect_error(merge(df1, df1, by = "V1"))
-  out <- merge(df1, df3, by = "V1")
-  expect_equal(out$dat[, 3], c(8, 7))
+})
+
+test_that("Merge two GADSdat objects",{
+  out <- merge(df1, df3, by = "ID1")
+  expect_equal(out$dat[, "V1"], c(3, 5, NA, NA))
+  expect_equal(out$dat[, "V2"], c(8, NA, 10, 9))
   expect_equal(nrow(out$labels), 3)
 })
 
+test_that("Merge two GADSdat objects while setting default missing value",{
+  out <- merge(df1, df3, by = "ID1", missingValue = -99, missingValLabel = "missing")
+  expect_equal(out$dat[, "V1"], c(3, 5, -99, -99))
+  expect_equal(out$dat[, "V2"], c(8, -99, 10, 9))
+  expect_equal(nrow(out$labels), 3)
+
+  # with existing NAs
+  df1b <- df1
+  df1b$dat[1, "V1"] <- NA
+  df3b <- df3
+  df3b$dat[2:3, "V2"] <- NA
+  out2 <- merge(df1b, df3b, by = "ID1", missingValue = -99, missingValLabel = "missing")
+  expect_equal(out2$dat[, "V1"], c(NA, 5, -99, -99))
+  expect_equal(out2$dat[, "V2"], c(8, -99, NA, NA))
+  expect_equal(nrow(out2$labels), 3)
+  expect_equal(out2$labels[2:3, "value"], c(-99, -99))
+  expect_equal(out2$labels[2:3, "valLabel"], c("missing", "missing"))
+  expect_equal(out2$labels[2:3, "missings"], c("miss", "miss"))
+})
+
 test_that("Inner join two GADSdat objects", {
-  df3 <- df1
-  mod_dat <- df3$dat
-  mod_dat[, "v3"] <- c(8, 7)
-  df3 <- suppressMessages(updateMeta(df3, mod_dat))
-  df3$dat[3, ] <- c(1, 2, 5)
-
-  out <- merge(df1, df3, by = "V1", all = F)
-  expect_equal(dim(out$dat), c(2, 3))
-
-  out2 <- merge(df1, df3, by = "V1", all = T)
-  expect_equal(dim(out2$dat), c(3, 3))
+  out <- merge(df1, df3, by = "ID1", all = FALSE)
+  expect_equal(dim(out$dat), c(1, 3))
 })


### PR DESCRIPTION
This feature addresses #1. If two `GADsdat` objects are merged, it is desirable to automatically assign a `missingValue` and a `missingValLabel` to the `NAs` created through merging.

I am not super happy with my implementation. The workaround using `intermediate_code` seems vulnerable and bad practice to me. However, I was unable to come up with a working and somewhat efficient alternative. Would be very happy to hear your thoughts on this.

Feature requested for BT24 data cleaning (@liebelta, @OtteKatrin, @burbliesj)