### PR TITLE
changeMissings: Fix bug with variables with one existing value label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * `inspectMetaDifferences()` now correctly reports differences for meta data with differing row names (#102)
 * hot fix for `existingMeta` argument in `recodeGADS()` and `applyChangeMeta()`, which was ignored when values were recoded into each other (#104)
 * fix unclear documentation in `removeValLabels()` (#111)
+* fix `changeMissings()` bug which dropped a single, existing value label and threw an error (#121)
 
 # eatGADS 1.1.1
 ## new features

--- a/R/changeMissings.R
+++ b/R/changeMissings.R
@@ -72,8 +72,10 @@ changeMissings.GADSdat <- function(GADSdat, varName, value, missings) {
     for(i in seq_along(new_values)) {
       change_row <- changeTable_ori[changeTable_ori$varName == single_varName, ][1, ]
 
-      # if no other value labels exist in the first place, omit original row
-      if(i == 1 && nrow(changeTable[changeTable$varName == single_varName, ]) == 1) {
+      # if no other value labels or missing tags exist in the first place, omit original row
+      if(i == 1 &&
+         is.na(changeTable[changeTable$varName == single_varName, "value"][1]) &&
+         nrow(changeTable[changeTable$varName == single_varName, ]) == 1) {
         changeTable <- changeTable[changeTable$varName != single_varName, ]
       }
 

--- a/tests/testthat/test_changeMissings.R
+++ b/tests/testthat/test_changeMissings.R
@@ -56,6 +56,16 @@ test_that("changemissings for adding value labels to unlabeled variable", {
   expect_equal(out$dat, dfUn$dat)
 })
 
+test_that("changemissings for adding value labels to unlabeled values but with exactly one existing value label for the variable", {
+  dfUn1 <- changeValLabels(dfUn, varName = "v1", value = 2, valLabel = "a label")
+  out <- changeMissings(dfUn1, varName = "v1", value = 1, missings = "miss")
+
+  expect_equal(out$labels[1:2, "missings"], c("miss", "valid"))
+  expect_equal(out$labels[1:2, "value"], 1:2)
+  expect_equal(out$labels[1:2, "valLabel"], c(NA, "a label"))
+  expect_equal(out$dat, dfUn$dat)
+})
+
 test_that("Adding value label bug", {
   dat_ori <- data.frame(ID = 1:5,
                         var1 = c(1, 3, 4, 1, -99),


### PR DESCRIPTION
This fixes a bug reported by @liebelta in #121. 

The bug occured on variables with exactly one existing value label or missing tag. This also affected `merge.GADSdat()`.

Really small PR and I am not available next week. Could maybe one of you have a small look at it today?