### PR TITLE
autoRecode: make new_oldValues unique to avoid problems with duplicate new values

### DIFF
--- a/R/autoRecode.R
+++ b/R/autoRecode.R
@@ -27,6 +27,10 @@
 #' # auto recode with saving look up table
 #' f <- tempfile(fileext = ".csv")
 #' gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num", csv_path = f)
+#'
+#' # auto recode with applying and expanding a look up table
+#' gads3 <- import_DF(data.frame(v2 = c(letters[1:3], "aa")))
+#' gads3 <- autoRecode(gads3, var = "v2", csv_path = f, template = read.csv(f))
 #'@export
 autoRecode <- function(GADSdat, var, var_suffix = "", label_suffix = "", csv_path = NULL, template = NULL) {
   UseMethod("autoRecode")
@@ -63,7 +67,7 @@ autoRecode.GADSdat <- function(GADSdat, var, var_suffix = "", label_suffix = "",
     }
 
     # recoding the actual data via a lookup table
-    new_oldValues <- GADSdat$dat[[var]][!GADSdat$dat[[var]] %in% template$oldValue]
+    new_oldValues <- unique(GADSdat$dat[[var]][!GADSdat$dat[[var]] %in% template$oldValue])
     new_newValues <- seq(from = max(template$newValue) + 1, length.out = length(new_oldValues))
     lookup <- rbind(template, data.frame(oldValue = new_oldValues, newValue = new_newValues))
     lookup_table <- data.frame(variable = new_var, lookup)

--- a/man/autoRecode.Rd
+++ b/man/autoRecode.Rd
@@ -47,4 +47,8 @@ gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num")
 # auto recode with saving look up table
 f <- tempfile(fileext = ".csv")
 gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num", csv_path = f)
+
+# auto recode with applying and expanding a look up table
+gads3 <- import_DF(data.frame(v2 = c(letters[1:3], "aa")))
+gads3 <- autoRecode(gads3, var = "v2", csv_path = f, template = read.csv(f))
 }

--- a/tests/testthat/test_autoRecode.R
+++ b/tests/testthat/test_autoRecode.R
@@ -67,3 +67,14 @@ test_that("existing lookup, no new cases", {
   expect_equal(lookup$newValue, 1:6)
 })
 
+test_that("existing lookup, duplicate new cases", {
+  existing_lookup <- data.frame(oldValue = c(112, 115), newValue = c(3, 6))
+
+  f <- tempfile(fileext = ".csv")
+  out <- autoRecode(g, var = "id", var_suffix = "_new", template = existing_lookup, csv_path = f)
+  expect_equal(out$dat$id_new, c(7, 6, 3, 7))
+
+  lookup <- read.csv(f)
+  expect_equal(lookup$oldValue, c(112, 115, 110))
+  expect_equal(lookup$newValue, c(3, 6, 7))
+})


### PR DESCRIPTION
This PR fixes #131 by making `new_oldValues` unique, and also adds a test to cover the problem described in the issue.

This is not urgent, but also a rather small PR, so maybe a review is possible until the end of next week?