### PR TITLE
recodeGADS: Fix sequential recodes for unlabeled values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eatGADS
 Title: Data Management of Large Hierarchical Data
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: c(
     person("Benjamin", "Becker", email = "b.becker@iqb.hu-berlin.de", role = c("aut", "cre")),
     person("Karoline", "Sachse", role = c("ctb")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# eatGADS 1.2.0.9000
+## bug fixes
+* `recodeGADS()` now correctly performs potentially sequential recodes for unlabeled values (#134)
+
 # eatGADS 1.2.0
 ## new features
 * `dropDuplicateIDs()` allows dropping duplicate IDs based on number of missings on selected variables (#67)

--- a/R/recodeGADS.R
+++ b/R/recodeGADS.R
@@ -73,12 +73,15 @@ recodeGADS.GADSdat <- function(GADSdat, varName, oldValues, newValues,
     }
     # recode values without labels (not the best solution but better usability)
     other_recodes <- which(!oldValues %in% changeTable[changeTable$varName == single_varName, "value"] & !is.na(oldValues))
-    for(i in other_recodes) {
-      if(!oldValues[i] %in% GADSdat$dat[, single_varName]) {
-        warning("The following value in 'oldValues' is neither a labeled value in the meta data nor an actual value in ",
-                single_varName, ": ", oldValues[i])
-      }
-      GADSdat$dat[which(GADSdat$dat[, single_varName] == oldValues[i]), single_varName] <- newValues[i]
+
+    if(length(other_recodes) > 0) {
+      data_recode_lookup <- data.frame(oldValues = oldValues[other_recodes], newValues = newValues[other_recodes])
+      not_in_data_aswell <- oldValues[!oldValues %in% GADSdat$dat[, single_varName]]
+      if(length(not_in_data_aswell) > 0) {
+          warning("The following values in 'oldValues' are neither a labeled value in the meta data nor an actual value in ",
+                  single_varName, ": ", not_in_data_aswell)
+        }
+      GADSdat$dat[, single_varName] <- eatTools::recodeLookup(GADSdat$dat[, single_varName], lookup = data_recode_lookup)
     }
   }
 

--- a/tests/testthat/test_recodeGADS.R
+++ b/tests/testthat/test_recodeGADS.R
@@ -18,7 +18,7 @@ test_that("Recode wrapper errors", {
   expect_error(recodeGADS(dfSAV, varName = "VAR1", oldValues = c(-99), newValues = c(1)),
                "Values in 'value_new' with existing meta data in variable VAR1: 1")
   expect_warning(out <- recodeGADS(dfSAV, varName = "VAR1", oldValues = c(3), newValues = c(10)),
-                 "The following value in 'oldValues' is neither a labeled value in the meta data nor an actual value in VAR1: 3")
+                 "The following values in 'oldValues' are neither a labeled value in the meta data nor an actual value in VAR1: 3")
   expect_equal(out, dfSAV)
 })
 
@@ -41,6 +41,14 @@ test_that("Recode wrapper for unlabeled values", {
 
   out2 <- recodeGADS(allG, varName = "VAR1", oldValues = c(2), newValues = c(10))
   expect_equal(out2$datList$dfSAV$VAR1, c(1, -99, -96, 10))
+})
+
+test_that("Recode wrapper avoids sequential recoding bug", {
+  gads <- import_DF(data.frame(x = 1:6, y = 1:6))
+  out <- recodeGADS(GADSdat = gads, var = "x", oldValues = 3:5,
+                         newValues = c(5, 14, 15))
+
+  expect_equal(out$dat$x, c(1, 2, 5, 14, 15, 6))
 })
 
 test_that("Recode wrapper for unlabeled variables", {


### PR DESCRIPTION
Uses eatTools::recodeLookup to increase performance and avoid any sequential issues.

Fixes the bug mentioned in #134, which occured for unlabeled values.