### PR TITLE
autoRecode: clarify behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # eatGADS 1.2.0.9000
 ## bug fixes
 * `autoRecode()` no longer fails while applying a template that does not yet cover a value which occurs in the data more than once (#131)
-* `changekMissings()` no longer throws an existing value error in edge cases with multiple existing value labels
+* `changeMissings()` no longer throws an existing value error in edge cases with multiple existing value labels
+
+## documentation
+* The behavior `autoRecode()` is further clarified, emphasizing the dropping of value labels and pointing to `multiChar2fac()` (#136).
 
 # eatGADS 1.2.0
 ## new features

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * `changeMissings()` no longer throws an existing value error in edge cases with multiple existing value labels
 
 ## documentation
-* The behavior `autoRecode()` is further clarified, emphasizing the dropping of value labels and pointing to `multiChar2fac()` (#136).
+* The behavior of `autoRecode()` is further clarified, emphasizing the dropping of value labels and pointing to `multiChar2fac()` (#136).
 
 # eatGADS 1.2.0
 ## new features

--- a/R/assimilateValLabels.R
+++ b/R/assimilateValLabels.R
@@ -4,12 +4,12 @@
 #'
 #' Assimilate all value labels of multiple variables as part of a \code{GADSdat} or \code{all_GADSdat} object.
 #'
-#' Assimilation can be performed using all existing value labels or a look up table containing at least all existing value labels.
+#' Assimilation can be performed using all existing value labels or a lookup table containing at least all existing value labels.
 #' Missing codes are reused based on the meta data of the first variable in \code{varNames}.
 #'
 #'@param GADSdat \code{GADSdat} object imported via \code{eatGADS}.
 #'@param varNames Character string of a variable name.
-#'@param lookup Look up \code{data.frame}.
+#'@param lookup Lookup \code{data.frame}.
 #'
 #'@return Returns the \code{GADSdat} object with changed meta data and recoded values.
 #'

--- a/R/autoRecode.R
+++ b/R/autoRecode.R
@@ -2,33 +2,41 @@
 #############################################################################
 #' Auto recode a variable in a \code{GADSdat}.
 #'
-#' Auto recode a variable in a \code{GADSdat}. A look up table is created containing the respective recode pairs.
-#' An existing look up table can be utilized via \code{template}. This function somewhat mirrors the functionality provided
-#' by the \code{SPSS} function \code{autorecode}.
+#' Auto recode a variable in a \code{GADSdat}, mirroring the core functionality provided by
+#'  \code{AUTORECODE} in \code{SPSS}. A lookup table containing the respective recode pairs can be
+#'  applied and/or saved.
 #'
-#' If an existing \code{template} is used and a look up table is saved as a \code{.csv} file, the resulting look up
-#' table will contain the existing recodes plus additional recode pairs required for the data.
+#' Existing values are replaced with sequential numbers, and all existing value-level metadata
+#'  (\code{valLabel} and \code{missings}) are dropped. This can be useful to remove confidential
+#'  information from ID variables. If the original (\code{character}) values are to be preserved as
+#'  \code{valLabel}s, \link{multiChar2fac} should be used instead.
+#'
+#' An existing \code{template} may be used to ensure that identical original values are recoded as
+#'  the same new values. The lookup table used to recode \code{var} may also be saved as a
+#'  \code{.csv} file, e.g. to be used as a \code{template} later. If both an existing \code{template}
+#'  is used and the lookup table is saved, the resulting lookup table will contain the existing
+#'  recodes and additional recode pairs required for the data, if any were needed.
 #'
 #'@param GADSdat A \code{GADSdat} object.
 #'@param var Character string of the variable name which should be recoded.
 #'@param var_suffix Variable suffix for the newly created \code{GADSdat}. If an empty character, the existing variables are overwritten.
 #'@param label_suffix Suffix added to variable label for the newly created variable in the \code{GADSdat}.
-#'@param csv_path Path for the \code{.csv} file for the look up table.
-#'@param template Existing look up table.
+#'@param csv_path Path for the \code{.csv} file for the lookup table.
+#'@param template Existing lookup table.
 #'
 #'@return Returns a \code{GADSdat} object.
 #'
 #'@examples
 #' gads <- import_DF(data.frame(v1 = letters))
 #'
-#' # auto recode without saving look up table
+#' # auto recode without saving lookup table
 #' gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num")
 #'
-#' # auto recode with saving look up table
+#' # auto recode with saving lookup table
 #' f <- tempfile(fileext = ".csv")
 #' gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num", csv_path = f)
 #'
-#' # auto recode with applying and expanding a look up table
+#' # auto recode with applying and expanding a lookup table
 #' gads3 <- import_DF(data.frame(v2 = c(letters[1:3], "aa")))
 #' gads3 <- autoRecode(gads3, var = "v2", csv_path = f,
 #'                     template = read.csv(f))
@@ -58,7 +66,7 @@ autoRecode.GADSdat <- function(GADSdat, var, var_suffix = "", label_suffix = "",
     # new variable to factor
     GADSdat_out <- multiChar2fac(GADSdat_out, vars = new_var, var_suffix = "", label_suffix = "")
 
-    # look up table
+    # lookup table
     lookup <- extractMeta(GADSdat_out, vars = new_var)[, c("valLabel", "value")]
     names(lookup) <- c("oldValue", "newValue")
     GADSdat_out <- removeValLabels(GADSdat_out, varName = new_var, value = c(lookup$newValue))

--- a/R/recode2NA.R
+++ b/R/recode2NA.R
@@ -7,7 +7,7 @@
 #' If there are value labels given to the specified value, a warning is issued. Number of recodes per variable are reported.
 #'
 #' If a data set is imported from \code{.sav}, character variables frequently contain empty strings. Especially if parts of the
-#' data are written to \code{.xlsx}, this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
+#' data are written to \code{.xlsx}, this can cause problems (e.g. as lookup tables from \code{\link{createLookup}}),
 #' as most function which write to \code{.xlsx} convert empty strings to \code{NAs}. \code{recodeString2NA} can be
 #' used to recode all empty strings to \code{NA} beforehand.
 #'

--- a/man/assimilateValLabels.Rd
+++ b/man/assimilateValLabels.Rd
@@ -11,7 +11,7 @@ assimilateValLabels(GADSdat, varNames, lookup = NULL)
 
 \item{varNames}{Character string of a variable name.}
 
-\item{lookup}{Look up \code{data.frame}.}
+\item{lookup}{Lookup \code{data.frame}.}
 }
 \value{
 Returns the \code{GADSdat} object with changed meta data and recoded values.
@@ -20,7 +20,7 @@ Returns the \code{GADSdat} object with changed meta data and recoded values.
 Assimilate all value labels of multiple variables as part of a \code{GADSdat} or \code{all_GADSdat} object.
 }
 \details{
-Assimilation can be performed using all existing value labels or a look up table containing at least all existing value labels.
+Assimilation can be performed using all existing value labels or a lookup table containing at least all existing value labels.
 Missing codes are reused based on the meta data of the first variable in \code{varNames}.
 }
 \examples{

--- a/man/autoRecode.Rd
+++ b/man/autoRecode.Rd
@@ -22,33 +22,42 @@ autoRecode(
 
 \item{label_suffix}{Suffix added to variable label for the newly created variable in the \code{GADSdat}.}
 
-\item{csv_path}{Path for the \code{.csv} file for the look up table.}
+\item{csv_path}{Path for the \code{.csv} file for the lookup table.}
 
-\item{template}{Existing look up table.}
+\item{template}{Existing lookup table.}
 }
 \value{
 Returns a \code{GADSdat} object.
 }
 \description{
-Auto recode a variable in a \code{GADSdat}. A look up table is created containing the respective recode pairs.
-An existing look up table can be utilized via \code{template}. This function somewhat mirrors the functionality provided
-by the \code{SPSS} function \code{autorecode}.
+Auto recode a variable in a \code{GADSdat}, mirroring the core functionality provided by
+ \code{AUTORECODE} in \code{SPSS}. A lookup table containing the respective recode pairs can be
+ applied and/or saved.
 }
 \details{
-If an existing \code{template} is used and a look up table is saved as a \code{.csv} file, the resulting look up
-table will contain the existing recodes plus additional recode pairs required for the data.
+Existing values are replaced with sequential numbers, and all existing value-level metadata
+ (\code{valLabel} and \code{missings}) are dropped. This can be useful to remove confidential
+ information from ID variables. If the original (\code{character}) values are to be preserved as
+ \code{valLabel}s, \link{multiChar2fac} should be used instead.
+
+An existing \code{template} may be used to ensure that identical original values are recoded as
+ the same new values. The lookup table used to recode \code{var} may also be saved as a
+ \code{.csv} file, e.g. to be used as a \code{template} later. If both an existing \code{template}
+ is used and the lookup table is saved, the resulting lookup table will contain the existing
+ recodes and additional recode pairs required for the data, if any were needed.
 }
 \examples{
 gads <- import_DF(data.frame(v1 = letters))
 
-# auto recode without saving look up table
+# auto recode without saving lookup table
 gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num")
 
-# auto recode with saving look up table
+# auto recode with saving lookup table
 f <- tempfile(fileext = ".csv")
 gads2 <- autoRecode(gads, var = "v1", var_suffix = "_num", csv_path = f)
 
-# auto recode with applying and expanding a look up table
+# auto recode with applying and expanding a lookup table
 gads3 <- import_DF(data.frame(v2 = c(letters[1:3], "aa")))
-gads3 <- autoRecode(gads3, var = "v2", csv_path = f, template = read.csv(f))
+gads3 <- autoRecode(gads3, var = "v2", csv_path = f,
+                    template = read.csv(f))
 }

--- a/man/recode2NA.Rd
+++ b/man/recode2NA.Rd
@@ -23,7 +23,7 @@ Recode multiple values in multiple variables in a \code{GADSdat} to \code{NA}.
 If there are value labels given to the specified value, a warning is issued. Number of recodes per variable are reported.
 
 If a data set is imported from \code{.sav}, character variables frequently contain empty strings. Especially if parts of the
-data are written to \code{.xlsx}, this can cause problems (e.g. as look up tables from \code{\link{createLookup}}),
+data are written to \code{.xlsx}, this can cause problems (e.g. as lookup tables from \code{\link{createLookup}}),
 as most function which write to \code{.xlsx} convert empty strings to \code{NAs}. \code{recodeString2NA} can be
 used to recode all empty strings to \code{NA} beforehand.
 }


### PR DESCRIPTION
This addresses the misunderstandings discussed in #136. The behavior of `autoRecode()` is further clarified, emphasizing that existing values and value labels will not be preserved, and pointing to `multiChar2fac()` if the preservation of original values as value labels is desired. Less importantly, the spelling of "lookup"/"look up" is being harmonized across the functions that use the term in their documentation.