### PR TITLE
checkVarNames: Add check of name lengths and fix arguments not being handed down

### DIFF
--- a/R/checkVarNames.R
+++ b/R/checkVarNames.R
@@ -44,23 +44,28 @@ checkVarNames <- function(GADSdat, checkKeywords = TRUE, checkDots = TRUE, check
 #'@export
 checkVarNames.GADSdat <- function(GADSdat, checkKeywords = TRUE, checkDots = TRUE, checkDuplicates = TRUE) {
   check_GADSdat(GADSdat)
-  GADSdat[["labels"]][, "varName"] <- sapply(GADSdat[["labels"]][, "varName"], checkVarNames)
-  names(GADSdat[["dat"]]) <- sapply(names(GADSdat[["dat"]]), checkVarNames)
+  GADSdat[["labels"]][, "varName"] <- sapply(GADSdat[["labels"]][, "varName"], checkVarNames,
+                                             checkKeywords, checkDots, checkDuplicates)
+  names(GADSdat[["dat"]]) <- sapply(names(GADSdat[["dat"]]), checkVarNames,
+                                    checkKeywords, checkDots, checkDuplicates)
   GADSdat
 }
 #'@export
 checkVarNames.all_GADSdat <- function(GADSdat, checkKeywords = TRUE, checkDots = TRUE, checkDuplicates = TRUE) {
   check_all_GADSdat(GADSdat)
-  GADSdat[["allLabels"]][, "varName"] <- sapply(GADSdat[["allLabels"]][, "varName"], checkVarNames)
+  GADSdat[["allLabels"]][, "varName"] <- sapply(GADSdat[["allLabels"]][, "varName"], checkVarNames,
+                                                checkKeywords, checkDots, checkDuplicates)
   GADSdat[["datList"]] <- lapply(GADSdat[["datList"]], function(df) {
-    names(df) <- sapply(names(df), checkVarNames)
+    names(df) <- sapply(names(df), checkVarNames,
+                        checkKeywords, checkDots, checkDuplicates)
     df
   })
   GADSdat
 }
 #'@export
 checkVarNames.data.frame <- function(GADSdat, checkKeywords = TRUE, checkDots = TRUE, checkDuplicates = TRUE) {
-  names(GADSdat) <- checkVarNames(names(GADSdat))
+  names(GADSdat) <- checkVarNames(names(GADSdat),
+                                  checkKeywords, checkDots, checkDuplicates)
   GADSdat
 }
 #'@export
@@ -72,7 +77,6 @@ checkVarNames.character <- function(GADSdat, checkKeywords = TRUE, checkDots = T
     stop("Column names can not be NA.")
   }
 
-  #browser()
   ## SQLite Keywords
   if(checkKeywords) {
     keyword_matches <- tolower(GADSdat) %in%  tolower(eatDB::sqlite_keywords)

--- a/man/checkVarNames.Rd
+++ b/man/checkVarNames.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/checkVarNames.R
 \name{checkVarNames}
 \alias{checkVarNames}
-\title{Check names for \code{SQLite} column name conventions.}
+\title{Check names for \code{SQLite} column name conventions and length limits.}
 \usage{
 checkVarNames(
   GADSdat,
   checkKeywords = TRUE,
   checkDots = TRUE,
-  checkDuplicates = TRUE
+  checkDuplicates = TRUE,
+  limits = c("SPSS", "Stata")
 )
 }
 \arguments{
@@ -19,13 +20,17 @@ checkVarNames(
 \item{checkDots}{Logical. Should occurrences of \code{"."} be checked and modified?}
 
 \item{checkDuplicates}{Logical. Should case insensitive duplicate variable names be checked and modified?}
+
+\item{limits}{Optional. Either \code{NULL} to disable the length check, or the program
+(\code{SPSS} or \code{Stata}) against whose limits the names should be checked.}
 }
 \value{
 Returns the original object with updated variable names.
 }
 \description{
-Checks names for \code{SQLite} column name conventions and
-applies appropriate variable name changes to \code{GADSdat} or \code{all_GADSdat} objects.
+Checks names for \code{SQLite} column name conventions and \code{SPSS}/\code{Stata}
+variable name limits, and applies appropriate variable name changes to
+\code{GADSdat} or \code{all_GADSdat} objects.
 }
 \details{
 Invalid column names in a \code{SQLite} data base include
@@ -35,15 +40,19 @@ Invalid column names in a \code{SQLite} data base include
 \item duplicate variable names which arise from \code{SQLite} being case insensitive.
 }
 
+Additionally, \code{SPSS} and \code{Stata} restrict the length of variable names to
+64 bytes (\code{SPSS}) or 32 characters (\code{Stata}).
+
 The corresponding variable name changes are
 \itemize{
 \item appending the suffix \code{"Var"} to all \code{SQLite} keywords,
-\item changing all \code{"."} in variable names to \code{"_"} and
-\item appending \code{"_2"} to case insensitive duplicated variable names.
+\item changing all \code{"."} in variable names to \code{"_"},
+\item appending \code{"_2"} to case insensitive duplicated variable names, and
+\item appending \code{"_tr"} to variable names exceeding the limits of the chosen program.
 }
 
 Note that avoiding \code{"."} in variable names is beneficial for multiple reasons, such as
-avoiding confusion with \code{S3} methods in \code{R} and issues when importing from \code{Stata}.
+avoiding confusion with \code{S3} methods in \code{R} and issues when exporting to \code{Stata}.
 }
 \examples{
 # Change example data set (create an invalid variable name)

--- a/tests/testthat/test_checkVarNames.R
+++ b/tests/testthat/test_checkVarNames.R
@@ -15,6 +15,23 @@ df4$labels[3, "valLabel"] <- "missing by design"
 df4$labels[3, "missings"] <- "valid"
 df4$labels[2:3, "labeled"] <- "yes"
 
+df5a <- data.frame(good.name = 1:3,
+                   group = letters[1:3])
+df5b <- data.frame(good_name = 1:3,
+                   groupVar = letters[1:3])
+
+GADS5a <- import_DF(df5a, checkVarNames = FALSE)
+GADS5b <- import_DF(df5b, checkVarNames = FALSE)
+rownames(GADS5b$labels) <- rownames(GADS5a$labels) <- NULL
+
+allGADS5b <- allGADS5a <- expected_bigList
+allGADS5a$datList$df2 <- allGADS5a$datList$df1 <- df5a
+allGADS5a$allLabels <- rbind(GADS5a$labels, GADS5a$labels)
+allGADS5b$datList$df2 <- allGADS5b$datList$df1 <- df5b
+allGADS5b$allLabels <- rbind(GADS5b$labels, GADS5b$labels)
+allGADS5b$datList$df2[2,] <- allGADS5a$datList$df2[2,] <- c(10, "x")
+allGADS5b$allLabels$data_table <- allGADS5a$allLabels$data_table <- c(rep("df1", 2), rep("df2", 2))
+
 
 test_that("Variable name are transformed correctly for character vectors", {
   expect_error(checkVarNames(c("group", "var.1", "Select", NA)),
@@ -75,4 +92,45 @@ test_that("Check varNames all_GADSdat", {
   #changed_df <- suppressMessages(checkVarNames(expected_bigList))
   #imported_df <- suppressMessages(import_DF(iris))
   #expect_equal(changed_df, imported_df)
+})
+
+test_that("Checks are only performed selectively, if requested", {
+  # only keywords
+  df_keywords_T <- checkVarNames(df5a, checkKeywords = TRUE, checkDots = FALSE)
+  expect_equal(names(df_keywords_T)[2], names(df5b)[2])
+  expect_equal(names(df_keywords_T)[1], names(df5a)[1])
+
+  GADS_keywords_T <- checkVarNames(GADS5a, checkKeywords = TRUE, checkDots = FALSE)
+  expect_equal(names(GADS_keywords_T$dat)[2], names(GADS5b$dat)[2])
+  expect_equal(names(GADS_keywords_T$dat)[1], names(GADS5a$dat)[1])
+  expect_equal(GADS_keywords_T$labels$varName[2], GADS5b$labels$varName[2])
+  expect_equal(GADS_keywords_T$labels$varName[1], GADS5a$labels$varName[1])
+
+  allGADS_keywords_T <- checkVarNames(allGADS5a, checkKeywords = TRUE, checkDots = FALSE)
+  expect_equal(names(allGADS_keywords_T$datList$df1)[2], names(allGADS5b$datList$df1)[2])
+  expect_equal(names(allGADS_keywords_T$datList$df2)[2], names(allGADS5b$datList$df2)[2])
+  expect_equal(names(allGADS_keywords_T$datList$df1)[1], names(allGADS5a$datList$df1)[1])
+  expect_equal(names(allGADS_keywords_T$datList$df2)[1], names(allGADS5a$datList$df2)[1])
+  expect_equal(unique(allGADS_keywords_T$allLabels$varName)[2], unique(allGADS5b$allLabels$varName)[2])
+  expect_equal(unique(allGADS_keywords_T$allLabels$varName)[1], unique(allGADS5a$allLabels$varName)[1])
+
+
+  # only dots
+  df_dots_T <- checkVarNames(df5a, checkKeywords = FALSE, checkDots = TRUE)
+  expect_equal(names(df_dots_T)[1], names(df5b)[1])
+  expect_equal(names(df_dots_T)[2], names(df5a)[2])
+
+  GADS_dots_T <- checkVarNames(GADS5a, checkKeywords = FALSE, checkDots = TRUE)
+  expect_equal(names(GADS_dots_T$dat)[1], names(GADS5b$dat)[1])
+  expect_equal(names(GADS_dots_T$dat)[2], names(GADS5a$dat)[2])
+  expect_equal(GADS_dots_T$labels$varName[1], GADS5b$labels$varName[1])
+  expect_equal(GADS_dots_T$labels$varName[2], GADS5a$labels$varName[2])
+
+  allGADS_dots_T <- checkVarNames(allGADS5a, checkKeywords = FALSE, checkDots = TRUE)
+  expect_equal(names(allGADS_dots_T$datList$df1)[1], names(allGADS5b$datList$df1)[1])
+  expect_equal(names(allGADS_dots_T$datList$df2)[1], names(allGADS5b$datList$df2)[1])
+  expect_equal(names(allGADS_dots_T$datList$df1)[2], names(allGADS5a$datList$df1)[2])
+  expect_equal(names(allGADS_dots_T$datList$df2)[2], names(allGADS5a$datList$df2)[2])
+  expect_equal(unique(allGADS_dots_T$allLabels$varName)[1], unique(allGADS5b$allLabels$varName)[1])
+  expect_equal(unique(allGADS_dots_T$allLabels$varName)[2], unique(allGADS5a$allLabels$varName)[2])
 })

--- a/tests/testthat/test_checkVarNames.R
+++ b/tests/testthat/test_checkVarNames.R
@@ -16,9 +16,11 @@ df4$labels[3, "missings"] <- "valid"
 df4$labels[2:3, "labeled"] <- "yes"
 
 df5a <- data.frame(good.name = 1:3,
-                   group = letters[1:3])
+                   group = letters[1:3],
+                   aaaüaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaüaaa = LETTERS[1:3])
 df5b <- data.frame(good_name = 1:3,
-                   groupVar = letters[1:3])
+                   groupVar = letters[1:3],
+                   aaaüaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_tr = LETTERS[1:3])
 
 GADS5a <- import_DF(df5a, checkVarNames = FALSE)
 GADS5b <- import_DF(df5b, checkVarNames = FALSE)
@@ -29,8 +31,8 @@ allGADS5a$datList$df2 <- allGADS5a$datList$df1 <- df5a
 allGADS5a$allLabels <- rbind(GADS5a$labels, GADS5a$labels)
 allGADS5b$datList$df2 <- allGADS5b$datList$df1 <- df5b
 allGADS5b$allLabels <- rbind(GADS5b$labels, GADS5b$labels)
-allGADS5b$datList$df2[2,] <- allGADS5a$datList$df2[2,] <- c(10, "x")
-allGADS5b$allLabels$data_table <- allGADS5a$allLabels$data_table <- c(rep("df1", 2), rep("df2", 2))
+allGADS5b$datList$df2[2,] <- allGADS5a$datList$df2[2,] <- c(10, "x", "GO")
+allGADS5b$allLabels$data_table <- allGADS5a$allLabels$data_table <- c(rep("df1", 3), rep("df2", 3))
 
 
 test_that("Variable name are transformed correctly for character vectors", {
@@ -94,43 +96,98 @@ test_that("Check varNames all_GADSdat", {
   #expect_equal(changed_df, imported_df)
 })
 
+test_that("Check and truncate long variable names", {
+  name32char <- paste0(substr(names(df5b)[3], 0, 29), "_tr")
+  df5c <- df5b
+  names(df5c)[3] <- name32char
+  GADS5c <- GADS5b
+  names(GADS5c$dat)[3] <- name32char
+  GADS5c$labels$varName[3] <- name32char
+  allGADS5c <- allGADS5b
+  names(allGADS5c$datList$df2)[3] <- names(allGADS5c$datList$df1)[3] <- name32char
+  allGADS5c$allLabels$varName <- gsub(pattern = names(df5b)[3],
+                                      replacement = name32char,
+                                      x = allGADS5c$allLabels$varName)
+
+  df_SPSS <- checkVarNames(df5a, limits = "SPSS")
+  df_Stata <- checkVarNames(df5a, limits = "Stata")
+  df_min <- checkVarNames(df5a, limits = c("Stata", "SPSS"))
+  expect_equal(df_SPSS, df5b)
+  expect_equal(df_Stata, df5c)
+  expect_equal(df_min, df5c)
+
+  GADS_SPSS <- checkVarNames(GADS5a, limits = "SPSS")
+  GADS_Stata <- checkVarNames(GADS5a, limits = "Stata")
+  GADS_min <- checkVarNames(GADS5a, limits = c("Stata", "SPSS"))
+  expect_equal(GADS_SPSS, GADS5b)
+  expect_equal(GADS_Stata, GADS5c)
+  expect_equal(GADS_min, GADS5c)
+
+  allGADS_SPSS <- checkVarNames(allGADS5a, limits = "SPSS")
+  allGADS_Stata <- checkVarNames(allGADS5a, limits = "Stata")
+  allGADS_min <- checkVarNames(allGADS5a, limits = c("Stata", "SPSS"))
+  expect_equal(allGADS_SPSS, allGADS5b)
+  expect_equal(allGADS_Stata, allGADS5c)
+  expect_equal(allGADS_min, allGADS5c)
+})
+
 test_that("Checks are only performed selectively, if requested", {
   # only keywords
   df_keywords_T <- checkVarNames(df5a, checkKeywords = TRUE, checkDots = FALSE)
   expect_equal(names(df_keywords_T)[2], names(df5b)[2])
-  expect_equal(names(df_keywords_T)[1], names(df5a)[1])
+  expect_equal(names(df_keywords_T)[c(1, 3)], names(df5a)[c(1, 3)])
 
   GADS_keywords_T <- checkVarNames(GADS5a, checkKeywords = TRUE, checkDots = FALSE)
   expect_equal(names(GADS_keywords_T$dat)[2], names(GADS5b$dat)[2])
-  expect_equal(names(GADS_keywords_T$dat)[1], names(GADS5a$dat)[1])
+  expect_equal(names(GADS_keywords_T$dat)[c(1, 3)], names(GADS5a$dat)[c(1, 3)])
   expect_equal(GADS_keywords_T$labels$varName[2], GADS5b$labels$varName[2])
-  expect_equal(GADS_keywords_T$labels$varName[1], GADS5a$labels$varName[1])
+  expect_equal(GADS_keywords_T$labels$varName[c(1, 3)], GADS5a$labels$varName[c(1, 3)])
 
   allGADS_keywords_T <- checkVarNames(allGADS5a, checkKeywords = TRUE, checkDots = FALSE)
   expect_equal(names(allGADS_keywords_T$datList$df1)[2], names(allGADS5b$datList$df1)[2])
   expect_equal(names(allGADS_keywords_T$datList$df2)[2], names(allGADS5b$datList$df2)[2])
-  expect_equal(names(allGADS_keywords_T$datList$df1)[1], names(allGADS5a$datList$df1)[1])
-  expect_equal(names(allGADS_keywords_T$datList$df2)[1], names(allGADS5a$datList$df2)[1])
+  expect_equal(names(allGADS_keywords_T$datList$df1)[c(1, 3)], names(allGADS5a$datList$df1)[c(1, 3)])
+  expect_equal(names(allGADS_keywords_T$datList$df2)[c(1, 3)], names(allGADS5a$datList$df2)[c(1, 3)])
   expect_equal(unique(allGADS_keywords_T$allLabels$varName)[2], unique(allGADS5b$allLabels$varName)[2])
-  expect_equal(unique(allGADS_keywords_T$allLabels$varName)[1], unique(allGADS5a$allLabels$varName)[1])
+  expect_equal(unique(allGADS_keywords_T$allLabels$varName)[c(1, 3)], unique(allGADS5a$allLabels$varName)[c(1, 3)])
 
 
   # only dots
   df_dots_T <- checkVarNames(df5a, checkKeywords = FALSE, checkDots = TRUE)
   expect_equal(names(df_dots_T)[1], names(df5b)[1])
-  expect_equal(names(df_dots_T)[2], names(df5a)[2])
+  expect_equal(names(df_dots_T)[2:3], names(df5a)[2:3])
 
   GADS_dots_T <- checkVarNames(GADS5a, checkKeywords = FALSE, checkDots = TRUE)
   expect_equal(names(GADS_dots_T$dat)[1], names(GADS5b$dat)[1])
-  expect_equal(names(GADS_dots_T$dat)[2], names(GADS5a$dat)[2])
+  expect_equal(names(GADS_dots_T$dat)[2:3], names(GADS5a$dat)[2:3])
   expect_equal(GADS_dots_T$labels$varName[1], GADS5b$labels$varName[1])
-  expect_equal(GADS_dots_T$labels$varName[2], GADS5a$labels$varName[2])
+  expect_equal(GADS_dots_T$labels$varName[2:3], GADS5a$labels$varName[2:3])
 
   allGADS_dots_T <- checkVarNames(allGADS5a, checkKeywords = FALSE, checkDots = TRUE)
   expect_equal(names(allGADS_dots_T$datList$df1)[1], names(allGADS5b$datList$df1)[1])
   expect_equal(names(allGADS_dots_T$datList$df2)[1], names(allGADS5b$datList$df2)[1])
-  expect_equal(names(allGADS_dots_T$datList$df1)[2], names(allGADS5a$datList$df1)[2])
-  expect_equal(names(allGADS_dots_T$datList$df2)[2], names(allGADS5a$datList$df2)[2])
+  expect_equal(names(allGADS_dots_T$datList$df1)[2:3], names(allGADS5a$datList$df1)[2:3])
+  expect_equal(names(allGADS_dots_T$datList$df2)[2:3], names(allGADS5a$datList$df2)[2:3])
   expect_equal(unique(allGADS_dots_T$allLabels$varName)[1], unique(allGADS5b$allLabels$varName)[1])
-  expect_equal(unique(allGADS_dots_T$allLabels$varName)[2], unique(allGADS5a$allLabels$varName)[2])
+  expect_equal(unique(allGADS_dots_T$allLabels$varName)[2:3], unique(allGADS5a$allLabels$varName)[2:3])
+
+
+  # only length
+  df_limits_T <- checkVarNames(df5a, checkKeywords = FALSE, checkDots = FALSE, limits = "SPSS")
+  expect_equal(names(df_limits_T)[3], names(df5b)[3])
+  expect_equal(names(df_limits_T)[1:2], names(df5a)[1:2])
+
+  GADS_limits_T <- checkVarNames(GADS5a, checkKeywords = FALSE, checkDots = FALSE, limits = "SPSS")
+  expect_equal(names(GADS_limits_T$dat)[3], names(GADS5b$dat)[3])
+  expect_equal(names(GADS_limits_T$dat)[1:2], names(GADS5a$dat)[1:2])
+  expect_equal(GADS_limits_T$labels$varName[3], GADS5b$labels$varName[3])
+  expect_equal(GADS_limits_T$labels$varName[1:2], GADS5a$labels$varName[1:2])
+
+  allGADS_limits_T <- checkVarNames(allGADS5a, checkKeywords = FALSE, checkDots = FALSE, limits = "SPSS")
+  expect_equal(names(allGADS_limits_T$datList$df1)[3], names(allGADS5b$datList$df1)[3])
+  expect_equal(names(allGADS_limits_T$datList$df2)[3], names(allGADS5b$datList$df2)[3])
+  expect_equal(names(allGADS_limits_T$datList$df1)[1:2], names(allGADS5a$datList$df1)[1:2])
+  expect_equal(names(allGADS_limits_T$datList$df2)[1:2], names(allGADS5a$datList$df2)[1:2])
+  expect_equal(unique(allGADS_limits_T$allLabels$varName)[3], unique(allGADS5b$allLabels$varName)[3])
+  expect_equal(unique(allGADS_limits_T$allLabels$varName)[1:2], unique(allGADS5a$allLabels$varName)[1:2])
 })


### PR DESCRIPTION
This addresses parts of both #110 and #138.

Specifically,...
- Regarding #110, problem number 6 is tackled by expanding `checkVarNames` to check the length of variables' names against the restrictions of `SPSS` or `Stata`. 
- Regarding #138, the first problem is addressed by ensuring `checkKeywords`, `checkDots`, and `checkDuplicates` are handed down from the "major" methods to `checkVarNames.character`.