### PR TITLE
check_functions: Recycle the argument's name if argName is not specified

### DIFF
--- a/R/applyChangeMeta.R
+++ b/R/applyChangeMeta.R
@@ -42,7 +42,7 @@ applyChangeMeta.varChanges <- function(changeTable, GADSdat, checkVarNames = TRU
   changeTable <- check_varChanges(changeTable, checkVarNames = checkVarNames)
   check_changeTable(GADSdat, changeTable)
   check_format_vector(changeTable$format_new)
-  check_logicalArgument(checkVarNames, argName = checkVarNames)
+  check_logicalArgument(checkVarNames)
 
   dat <- GADSdat$dat
   labels <- GADSdat$labels

--- a/R/autoRecode.R
+++ b/R/autoRecode.R
@@ -47,7 +47,7 @@ autoRecode <- function(GADSdat, var, var_suffix = "", label_suffix = "", csv_pat
 #'@export
 autoRecode.GADSdat <- function(GADSdat, var, var_suffix = "", label_suffix = "", csv_path = NULL, template = NULL) {
   check_GADSdat(GADSdat)
-  check_single_varName(var)
+  check_characterArgument(var)
   check_vars_in_GADSdat(GADSdat, vars = c(var))
 
   # duplicate

--- a/R/changeVarNames.R
+++ b/R/changeVarNames.R
@@ -42,7 +42,7 @@ changeVarNames.all_GADSdat <- function(GADSdat, oldNames, newNames, checkVarName
 #'@export
 changeVarNames.GADSdat <- function(GADSdat, oldNames, newNames, checkVarNames = TRUE) {
   check_GADSdat(GADSdat)
-  check_logicalArgument(checkVarNames, argName = checkVarNames)
+  check_logicalArgument(checkVarNames)
 
   checkNamesVectors(oldNames = oldNames, newNames = newNames, dat = GADSdat[["dat"]])
   changeTable <- getChangeMeta(GADSdat, level = "variable")

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -23,6 +23,9 @@ check_vars_in_vector <- function(vec, vars, vec_nam) {
 }
 
 check_logicalArgument <- function(arg, argName) {
+  if (missing(argName)) {
+    argName <- deparse(substitute(arg))
+  }
   if(!is.logical(arg) || length(arg) != 1) {
     stop("'", argName, "' needs to be a logical vector of length 1.")
   }
@@ -30,6 +33,9 @@ check_logicalArgument <- function(arg, argName) {
 }
 
 check_characterArgument <- function(arg, argName) {
+  if (missing(argName)) {
+    argName <- deparse(substitute(arg))
+  }
   if(!is.character(arg) || length(arg) != 1) {
     stop("'", argName, "' needs to be a character vector of length 1.")
   }
@@ -37,6 +43,9 @@ check_characterArgument <- function(arg, argName) {
 }
 
 check_numericArgument <- function(arg, argName) {
+  if (missing(argName)) {
+    argName <- deparse(substitute(arg))
+  }
   if(!is.numeric(arg) || length(arg) != 1) {
     stop("'", argName, "' needs to be a numeric vector of length 1.")
   }

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -1,24 +1,28 @@
 check_vars_in_GADSdat <- function(GADSdat, vars, argName = "vars", GADSdatName = "GADSdat") {
   dup_vars <- vars[duplicated(vars)]
   if(length(dup_vars) > 0) stop("There are duplicates in '", argName,"': ",
-                                paste(dup_vars, collapse = ", "))
+                                paste(dup_vars, collapse = ", "),
+                                call. = FALSE)
 
   nams <- namesGADS(GADSdat)
   if(is.list(nams)) nams <- unlist(nams)
   other_vars <- vars[!vars %in% nams]
   if(length(other_vars) > 0) stop("The following '", argName,"' are not variables in the ", GADSdatName, ": ",
-                                  paste(other_vars, collapse = ", "))
+                                  paste(other_vars, collapse = ", "),
+                                  call. = FALSE)
   return()
 }
 
 check_vars_in_vector <- function(vec, vars, vec_nam) {
   dup_vars <- vars[duplicated(vars)]
   if(length(dup_vars) > 0) stop("There are duplicates in 'vars': ",
-                                paste(dup_vars, collapse = ", "))
+                                paste(dup_vars, collapse = ", "),
+                                call. = FALSE)
 
   other_vars <- vars[!vars %in% vec]
   if(length(other_vars) > 0) stop("The following 'vars' are not variables in the ", vec_nam, ": ",
-                                  paste(other_vars, collapse = ", "))
+                                  paste(other_vars, collapse = ", "),
+                                  call. = FALSE)
   return()
 }
 
@@ -27,7 +31,8 @@ check_logicalArgument <- function(arg, argName) {
     argName <- deparse(substitute(arg))
   }
   if(!is.logical(arg) || length(arg) != 1) {
-    stop("'", argName, "' needs to be a logical vector of length 1.")
+    stop("'", argName, "' needs to be a logical vector of length 1.",
+         call. = FALSE)
   }
   return()
 }
@@ -37,7 +42,8 @@ check_characterArgument <- function(arg, argName) {
     argName <- deparse(substitute(arg))
   }
   if(!is.character(arg) || length(arg) != 1) {
-    stop("'", argName, "' needs to be a character vector of length 1.")
+    stop("'", argName, "' needs to be a character vector of length 1.",
+         call. = FALSE)
   }
   return()
 }
@@ -47,7 +53,8 @@ check_numericArgument <- function(arg, argName) {
     argName <- deparse(substitute(arg))
   }
   if(!is.numeric(arg) || length(arg) != 1) {
-    stop("'", argName, "' needs to be a numeric vector of length 1.")
+    stop("'", argName, "' needs to be a numeric vector of length 1.",
+         call. = FALSE)
   }
   return()
 }

--- a/R/check_functions.R
+++ b/R/check_functions.R
@@ -1,10 +1,3 @@
-check_single_varName <- function(var, argumentName = "varName") {
-  if(!is.character(var)) stop("'", argumentName, "' is not a character vector.")
-  if(!length(var) == 1) stop("'", argumentName, "' must be of length 1.")
-  return()
-}
-
-
 check_vars_in_GADSdat <- function(GADSdat, vars, argName = "vars", GADSdatName = "GADSdat") {
   dup_vars <- vars[duplicated(vars)]
   if(length(dup_vars) > 0) stop("There are duplicates in '", argName,"': ",

--- a/R/cloneVariable.R
+++ b/R/cloneVariable.R
@@ -26,7 +26,7 @@ cloneVariable <- function(GADSdat, varName, new_varName, label_suffix = "", chec
 cloneVariable.GADSdat <- function(GADSdat, varName, new_varName, label_suffix = "", checkVarName = TRUE) {
   check_GADSdat(GADSdat)
   check_vars_in_GADSdat(GADSdat, vars = varName)
-  check_logicalArgument(checkVarName, argName = checkVarName)
+  check_logicalArgument(checkVarName)
   if(new_varName %in% namesGADS(GADSdat)) {
     stop("'",  new_varName, "' is already an existing variable in the 'GADSdat'.")
   }

--- a/R/createVariable.R
+++ b/R/createVariable.R
@@ -21,7 +21,7 @@ createVariable <- function(GADSdat, varName, checkVarName = TRUE) {
 #'@export
 createVariable.GADSdat <- function(GADSdat, varName, checkVarName = TRUE) {
   check_GADSdat(GADSdat)
-  check_logicalArgument(checkVarName, argName = checkVarName)
+  check_logicalArgument(checkVarName)
   if(varName %in% namesGADS(GADSdat)) {
     stop("'",  varName, "' is already an existing variable in the 'GADSdat'.")
   }

--- a/R/dropDuplicateIDs.R
+++ b/R/dropDuplicateIDs.R
@@ -35,7 +35,7 @@ dropDuplicateIDs <- function(GADSdat, ID, varNames = setdiff(namesGADS(GADSdat),
 #'@export
 dropDuplicateIDs.GADSdat <- function(GADSdat, ID, varNames = setdiff(namesGADS(GADSdat), ID)) {
   check_GADSdat(GADSdat)
-  check_single_varName(ID, argumentName = "ID")
+  check_characterArgument(ID, argName = "ID")
   check_vars_in_GADSdat(GADSdat, vars = ID, argName = "ID")
   check_vars_in_GADSdat(GADSdat, vars = varNames, argName = "varNames")
 

--- a/R/relocateVariable.R
+++ b/R/relocateVariable.R
@@ -28,14 +28,14 @@ relocateVariable <- function(GADSdat, var, after = NULL) {
 #'@export
 relocateVariable.GADSdat <- function(GADSdat, var, after = NULL) {
   check_GADSdat(GADSdat)
-  check_single_varName(var)
+  check_characterArgument(var)
   check_vars_in_GADSdat(GADSdat, vars = var)
 
   nams <- namesGADS(GADSdat)
   where_var <- match(var, nams)
 
   if(!is.null(after)) {
-    check_single_varName(after)
+    check_characterArgument(after)
     check_vars_in_GADSdat(GADSdat, vars = after)
     where_after <- match(after, nams)
   } else {

--- a/R/updateMeta.R
+++ b/R/updateMeta.R
@@ -26,7 +26,7 @@ updateMeta <- function(GADSdat, newDat, checkVarNames = TRUE) {
 #'@export
 updateMeta.GADSdat <- function(GADSdat, newDat, checkVarNames = TRUE) {
   check_GADSdat(GADSdat)
-  check_logicalArgument(checkVarNames, argName = checkVarNames)
+  check_logicalArgument(checkVarNames)
   if(!identical(class(newDat), "data.frame")) stop("newDat needs to be a data.frame. Use as.data.frame is necessary.")
   labels <- GADSdat[["labels"]]
   labels <- remove_rows_meta(labels = labels, allNames = names(newDat))

--- a/tests/testthat/test_check_functions.R
+++ b/tests/testthat/test_check_functions.R
@@ -2,15 +2,6 @@
 # dfSAV <- import_spss(file = "tests/testthat/helper_spss_missings.sav")
 dfSAV <- import_spss(file = "helper_spss_missings.sav")
 
-test_that("check_single_varName", {
-  expect_error(check_single_varName(var = c("VAR1", "VAR1")),
-               "'varName' must be of length 1.")
-  expect_error(check_single_varName(var = 1),
-               "'varName' is not a character vector.")
-  expect_error(check_single_varName(var = 1, argumentName = "someArgument"),
-               "'someArgument' is not a character vector.")
-})
-
 
 test_that("check_vars_in_GADSdat", {
   expect_error(check_vars_in_GADSdat(dfSAV, vars = c("VAR1", "VAR1")),

--- a/tests/testthat/test_check_functions.R
+++ b/tests/testthat/test_check_functions.R
@@ -51,8 +51,8 @@ test_that("check_numericArgument", {
 
 test_that("Argument name is recycled if no argName is provided", {
   somearg <- "test"
-  expect_match(try(check_logicalArgument(somearg)), "*?somearg*?")
-  expect_match(try(check_numericArgument(somearg)), "*?somearg*?")
+  expect_match(try(check_logicalArgument(somearg), silent = TRUE), "*?somearg*?")
+  expect_match(try(check_numericArgument(somearg), silent = TRUE), "*?somearg*?")
   somearg <- 5
-  expect_match(try(check_characterArgument(somearg)), "*?somearg*?")
+  expect_match(try(check_characterArgument(somearg), silent = TRUE), "*?somearg*?")
 })

--- a/tests/testthat/test_check_functions.R
+++ b/tests/testthat/test_check_functions.R
@@ -51,8 +51,8 @@ test_that("check_numericArgument", {
 
 test_that("Argument name is recycled if no argName is provided", {
   somearg <- "test"
-  expect_match(try(check_logicalArgument(somearg), silent = TRUE), "*?somearg*?")
-  expect_match(try(check_numericArgument(somearg), silent = TRUE), "*?somearg*?")
+  expect_error(check_logicalArgument(somearg), "'somearg' needs to be a logical vector of length 1.")
+  expect_error(check_numericArgument(somearg), "'somearg' needs to be a numeric vector of length 1.")
   somearg <- 5
-  expect_match(try(check_characterArgument(somearg), silent = TRUE), "*?somearg*?")
+  expect_error(check_characterArgument(somearg), "'somearg' needs to be a character vector of length 1.")
 })

--- a/tests/testthat/test_check_functions.R
+++ b/tests/testthat/test_check_functions.R
@@ -48,3 +48,11 @@ test_that("check_numericArgument", {
                "'test' needs to be a numeric vector of length 1.")
   expect_silent(check_numericArgument(1, "test"))
 })
+
+test_that("Argument name is recycled if no argName is provided", {
+  somearg <- "test"
+  expect_match(try(check_logicalArgument(somearg)), "*?somearg*?")
+  expect_match(try(check_numericArgument(somearg)), "*?somearg*?")
+  somearg <- 5
+  expect_match(try(check_characterArgument(somearg)), "*?somearg*?")
+})


### PR DESCRIPTION
Closes #140 by enabling the mini checks to recycle `arg` if `argName` is missing. In cases where these functions were used with minor errors, these are corrected throughout the package. Additionally, `check_single_varName` is being removed and `check_characterArgument` is used in its stead.

Not an urgent PR.

Going forward, I wondered whether it would make sense to further standardize some of the mini checks that are being performed at multiple points in the package, e.g., checking if an argument is a numeric or character vector of exactly length x or at least length y.